### PR TITLE
Updating old proxy and example paths to app server and framework

### DIFF
--- a/bin/nodeCluster.bat
+++ b/bin/nodeCluster.bat
@@ -11,7 +11,7 @@ if "%ZLUX_NODE_LOG_DIR%" == "" (
   set ZLUX_NODE_LOG_DIR="../log"
 )
 call :makedir %ZLUX_NODE_LOG_DIR%
-set NODE_PATH=../../zlux-proxy-server/js/node_modules;%NODE_PATH%
+set NODE_PATH=../../zlux-server-framework/js/node_modules;%NODE_PATH%
 cd ../js
 set minWorkers=2
 set NODE_CLUSTER_SCHED_POLICY=rr

--- a/bin/nodeCluster.sh
+++ b/bin/nodeCluster.sh
@@ -111,7 +111,7 @@ fi
 #Determined log file.  Run node appropriately.
 export dir=`dirname "$0"`
 cd $dir
-export NODE_PATH=../../zlux-proxy-server/js/node_modules:$NODE_PATH
+export NODE_PATH=../../zlux-server-framework/js/node_modules:$NODE_PATH
 cd ../js
 
 if [ -n "$NODE_HOME" ]

--- a/bin/nodeServer.bat
+++ b/bin/nodeServer.bat
@@ -11,7 +11,7 @@ if "%ZLUX_NODE_LOG_DIR%" == "" (
   set ZLUX_NODE_LOG_DIR="../log"
 )
 call :makedir %ZLUX_NODE_LOG_DIR%
-set NODE_PATH=../../zlux-proxy-server/js/node_modules;%NODE_PATH%
+set NODE_PATH=../../zlux-server-framework/js/node_modules;%NODE_PATH%
 cd ../js
 node --harmony zluxServer.js --config=../deploy/instance/ZLUX/serverConfig/zluxserver.json %* > %ZLUX_NODE_LOG_DIR%\nodeServer.log 2>&1
 endlocal

--- a/bin/nodeServer.sh
+++ b/bin/nodeServer.sh
@@ -111,7 +111,7 @@ fi
 #Determined log file.  Run node appropriately.
 export dir=`dirname "$0"`
 cd $dir
-export NODE_PATH=../../zlux-proxy-server/js/node_modules:$NODE_PATH
+export NODE_PATH=../../zlux-server-framework/js/node_modules:$NODE_PATH
 cd ../js
 
 if [ -n "$NODE_HOME" ]

--- a/bin/zlux-install-script.sh
+++ b/bin/zlux-install-script.sh
@@ -16,18 +16,18 @@ pax -r -w -px ZLUX.pax $ZOE_ROOT_DIR
 cd $ZOE_ROOT_DIR
 pax -r -px -f ZLUX.pax
 
-chmod -R a-w tn3270-ng2/ vt-ng2/ zlux-app-manager/ zlux-example-server/ zlux-ng2/ zlux-proxy-server/ zlux-shared/ zos-subsystems/ 2>/dev/null
-chmod ug+w zlux-example-server/
-mkdir zlux-example-server/log
-chmod ug-w zlux-example-server/
+chmod -R a-w tn3270-ng2/ vt-ng2/ zlux-app-manager/ zlux-app-server/ zlux-ng2/ zlux-server-framework/ zlux-shared/ zos-subsystems/ 2>/dev/null
+chmod ug+w zlux-app-server/
+mkdir zlux-app-server/log
+chmod ug-w zlux-app-server/
 
-cd zlux-example-server
+cd zlux-app-server
 chmod -R a-w bin/ build/ config/ js/ plugins/ .gitattributes .gitignore README.md 2>/dev/null
 chmod ug+w bin/zssServer
 
 if extattr bin/zssServer | grep "APF authorized = NO"; then
   echo "zssServer does not have the proper extattr values"
-  echo "Please run extattr +a zlux-example-server/bin/zssServer"
+  echo "Please run extattr +a zlux-app-server/bin/zssServer"
   cd $SCRIPT_DIR
   return 1
 fi

--- a/js/zluxArgs.js
+++ b/js/zluxArgs.js
@@ -11,9 +11,9 @@
 */
 
 'use strict';
-const ProxyServer = require('../../zlux-proxy-server/js/index');
-const argParser = require('../../zlux-proxy-server/js/argumentParser.js');
-const jsonUtils = require('../../zlux-proxy-server/js/jsonUtils.js');
+const ProxyServer = require('../../zlux-server-framework/js/index');
+const argParser = require('../../zlux-server-framework/js/argumentParser.js');
+const jsonUtils = require('../../zlux-server-framework/js/jsonUtils.js');
 
 const PRODUCT_CODE = 'ZLUX';
 

--- a/js/zluxCluster.js
+++ b/js/zluxCluster.js
@@ -10,7 +10,7 @@
 */
 'use strict';
 
-const clusterManager = require('../../zlux-proxy-server/js/clusterManager').clusterManager;
+const clusterManager = require('../../zlux-server-framework/js/clusterManager').clusterManager;
 const {appConfig, configJSON, startUpConfig} = require('./zluxArgs')();
 
 clusterManager.start(appConfig, configJSON, startUpConfig);

--- a/js/zluxServer.js
+++ b/js/zluxServer.js
@@ -11,7 +11,7 @@
 */
 
 'use strict';
-const ProxyServer = require('../../zlux-proxy-server/js/index');
+const ProxyServer = require('../../zlux-server-framework/js/index');
 
 const {appConfig, configJSON, startUpConfig} = require('./zluxArgs')();
 const proxyServer = new ProxyServer(appConfig, configJSON, startUpConfig);

--- a/plugins/org.zowe.configjs.json
+++ b/plugins/org.zowe.configjs.json
@@ -1,4 +1,4 @@
 {
   "identifier": "org.zowe.configjs",
-  "pluginLocation": "../../zlux-proxy-server/plugins/config"
+  "pluginLocation": "../../zlux-server-framework/plugins/config"
 }

--- a/plugins/org.zowe.terminal.proxy.json
+++ b/plugins/org.zowe.terminal.proxy.json
@@ -1,4 +1,4 @@
 {
   "identifier": "org.zowe.terminal.proxy",
-  "pluginLocation": "../../zlux-proxy-server/plugins/terminal-proxy"
+  "pluginLocation": "../../zlux-server-framework/plugins/terminal-proxy"
 }

--- a/plugins/org.zowe.zlux.auth.trivial.json
+++ b/plugins/org.zowe.zlux.auth.trivial.json
@@ -1,4 +1,4 @@
 {
   "identifier": "org.zowe.zlux.auth.trivial",
-  "pluginLocation": "../../zlux-proxy-server/plugins/trivial-auth"
+  "pluginLocation": "../../zlux-server-framework/plugins/trivial-auth"
 }


### PR DESCRIPTION
zlux-proxy-server was renamed to zlux-server-framework, and zlux-example-server was renamed to zlux-app-server. There was some hardcoding so this should remedy it.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>