### PR TITLE
Default configuration for tomcat usage

### DIFF
--- a/config/tomcat.xml
+++ b/config/tomcat.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="${shutdown.port}" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         sslProtocol/protocols: https://docs.oracle.com/javase/7/docs/technotes/guides/security/StandardNames.html#SSLContext
+    -->
+    <Connector port="${https.port}" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               maxThreads="150"
+               SSLEnabled="true"
+               scheme="https"
+               secure="true"
+               SSLVerifyClient="none"
+               SSLProtocol="TLSv1.2"
+               SSLCipherSuite="HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!kRSA:!SHA1"
+               SSLCertificateFile="${https.certificate}"
+               SSLCertificateKeyFile="${https.key}">         
+    </Connector>
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <!-- UnpackWARS: https://wiki.apache.org/tomcat/RemoveUnpackWARs
+           appBase: Made customizable so that we can point to zowe app services
+      -->
+      <Host name="localhost"  appBase="${appdir}"
+            unpackWARs="false" autoDeploy="true">
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/config/tomcat.xml
+++ b/config/tomcat.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Licensed to the Apache Software Foundation (ASF) under one or more
-  contributor license agreements.  See the NOTICE file distributed with
-  this work for additional information regarding copyright ownership.
-  The ASF licenses this file to You under the Apache License, Version 2.0
-  (the "License"); you may not use this file except in compliance with
-  the License.  You may obtain a copy of the License at
+  This program and the accompanying materials are
+  made available under the terms of the Eclipse Public License v2.0 which accompanies
+  this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+  
+  SPDX-License-Identifier: EPL-2.0
+  
+  Copyright Contributors to the Zowe Project.
 
-      http://www.apache.org/licenses/LICENSE-2.0
+  This file inspired by the standard tomcat configuration XML, licensed to
+  The Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  
+  You may obtain a copy of that License at:
 
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
+  http://www.apache.org/licenses/LICENSE-2.0
 -->
 <!-- Note:  A "Server" is not itself a "Container", so you may not
      define subcomponents such as "Valves" at this level.

--- a/config/zluxserver.json
+++ b/config/zluxserver.json
@@ -41,22 +41,7 @@
   "groupsDir":"../deploy/instance/groups",
   "usersDir":"../deploy/instance/users",
   "pluginsDir":"../deploy/instance/ZLUX/plugins",
-  "languages": {
-    "java": {
-      "war": {
-        "javaAppServer": {
-          "type": "tomcat",
-          "path": "../../zlux-server-framework/lib/java/apache-tomcat-9.0.16",
-          "config": "../deploy/instance/ZLUX/serverConfig/tomcat.xml",
-          "https": {
-            "key": "../deploy/product/ZLUX/serverConfig/zlux.keystore.key",
-            "certificate": "../deploy/product/ZLUX/serverConfig/zlux.keystore.cer"
-          }
-        }
-      },
-      "portRange": [8550,8600]
-    }
-  },
+
   "dataserviceAuthentication": {
     //this specifies the default authentication type for dataservices that didn't specify which type to use. These dataservices therefore should not expect a particular type of authentication to be used.
     "defaultAuthentication": "zss",

--- a/config/zluxserver.json
+++ b/config/zluxserver.json
@@ -41,7 +41,22 @@
   "groupsDir":"../deploy/instance/groups",
   "usersDir":"../deploy/instance/users",
   "pluginsDir":"../deploy/instance/ZLUX/plugins",
-
+  "languages": {
+    "java": {
+      "war": {
+        "javaAppServer": {
+          "type": "tomcat",
+          "path": "../../zlux-server-framework/lib/java/apache-tomcat-9.0.16",
+          "config": "../deploy/instance/ZLUX/serverConfig/tomcat.xml",
+          "https": {
+            "key": "../deploy/product/ZLUX/serverConfig/zlux.keystore.key",
+            "certificate": "../deploy/product/ZLUX/serverConfig/zlux.keystore.cer"
+          }
+        }
+      },
+      "portRange": [8550,8600],
+    }
+  },
   "dataserviceAuthentication": {
     //this specifies the default authentication type for dataservices that didn't specify which type to use. These dataservices therefore should not expect a particular type of authentication to be used.
     "defaultAuthentication": "zss",

--- a/config/zluxserver.json
+++ b/config/zluxserver.json
@@ -54,7 +54,7 @@
           }
         }
       },
-      "portRange": [8550,8600],
+      "portRange": [8550,8600]
     }
   },
   "dataserviceAuthentication": {


### PR DESCRIPTION
To utilize https://github.com/zowe/zlux-server-framework/pull/92 configuration changes are needed. This provides a tomcat xml configuration file which has substitutions for values that need to be determined dynamically, such as which port to listen on, depending on the quantity of servers needed.
This also specifies a new body in zluxserver.json which is needed to alert zlux to a configuration that can find & manage java & tomcat.