### PR TITLE
Small script fix for shebang, which to type

### DIFF
--- a/bin/nodeCluster.sh
+++ b/bin/nodeCluster.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
@@ -133,8 +133,8 @@ export minWorkers=2
 
 echo Show Environment
 env
-echo Show which node
-which node
+echo Show location of node
+type node
 
 
 echo Starting node

--- a/bin/nodeServer.sh
+++ b/bin/nodeServer.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 # This program and the accompanying materials are
 # made available under the terms of the Eclipse Public License v2.0 which accompanies
 # this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html


### PR DESCRIPTION
'which' doesnt exist unless you have bash (most likely), so type is a safer command.
#! may or may not be read, but having no space is safer.
Signed-off-by: Sean Grady <sgrady@rocketsoftware.com>