### PR TITLE
Rewrite config

### DIFF
--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -148,17 +148,17 @@ if (!userInput.config) {
 const configJSON = DEFAULT_CONFIG;
 const userConfig = jsonUtils.parseJSONWithComments(userInput.config);
 let hostPort;
-let eUser = userInput.mlUser;
-let ePass = userInput.mlPass;
-if(eUser && ePass){
-  configJSON.node.mediationLayer.enabled = true;
-  configJSON.node.mediationLayer.instance.instanceId = `${configJSON.node.mediationLayer.instance.app}:${Math.floor(Math.random() * 9999)}`;
-  configJSON.node.mediationLayer.eureka.serviceUrls.default = [`http://${eUser}:${ePass}@${configJSON.node.mediationLayer.server.hostname}:${configJSON.node.mediationLayer.server.port}/eureka/apps/`];
-}
 for (const attribute in userConfig) { 
   configJSON[attribute] = userConfig[attribute]; 
 }
 if(process.env.overrideFileConfig != "false"){
+  let eUser = userInput.mlUser;
+  let ePass = userInput.mlPass;
+  if(eUser && ePass){
+    configJSON.node.mediationLayer.enabled = true;
+    configJSON.node.mediationLayer.instance.instanceId = `${configJSON.node.mediationLayer.instance.app}:${Math.floor(Math.random() * 9999)}`;
+    configJSON.node.mediationLayer.eureka.serviceUrls.default = [`http://${eUser}:${ePass}@${configJSON.node.mediationLayer.server.hostname}:${configJSON.node.mediationLayer.server.port}/eureka/apps/`];
+  }
   hostPort = userInput.hostPort;
   if(userInput.noPrompt){
     noPrompt = true;

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -79,6 +79,9 @@ const DEFAULT_CONFIG = {
   "pluginsDir":"../deploy/instance/"+PRODUCT_CODE+"/plugins",
 
   "node": {
+    "allowInvalidTLSProxy": false,
+    "noChild": false,
+    "noPrompt": false,
     "https": {
       "ipAddresses": ["0.0.0.0"],
       "port": 8544,
@@ -135,10 +138,8 @@ var commandArgs = process.argv.slice(2);
 var argumentParser = argParser.createParser(MVD_ARGS);
 var userInput = argumentParser.parse(commandArgs);
 var noPrompt = false;
+var allowInvalidTLS = false;
 
-if (userInput.noPrompt) {
-  noPrompt = true;
-}
 if (!userInput.config) {
   console.log('Missing one or more parameters required to run.');
   console.log('config file was '+userInput.config);
@@ -146,10 +147,7 @@ if (!userInput.config) {
 }
 const configJSON = DEFAULT_CONFIG;
 const userConfig = jsonUtils.parseJSONWithComments(userInput.config);
-for (const attribute in userConfig) { 
-  configJSON[attribute] = userConfig[attribute]; 
-}
-let hostPort = userInput.hostPort;
+let hostPort;
 let eUser = userInput.mlUser;
 let ePass = userInput.mlPass;
 if(eUser && ePass){
@@ -157,7 +155,33 @@ if(eUser && ePass){
   configJSON.node.mediationLayer.instance.instanceId = `${configJSON.node.mediationLayer.instance.app}:${Math.floor(Math.random() * 9999)}`;
   configJSON.node.mediationLayer.eureka.serviceUrls.default = [`http://${eUser}:${ePass}@${configJSON.node.mediationLayer.server.hostname}:${configJSON.node.mediationLayer.server.port}/eureka/apps/`];
 }
-if (!hostPort) {
+for (const attribute in userConfig) { 
+  configJSON[attribute] = userConfig[attribute]; 
+}
+if(process.env.overrideFileConfig != "false"){
+  hostPort = userInput.hostPort;
+  if(userInput.noPrompt){
+    noPrompt = true;
+  }
+  if(noPrompt){
+    configJSON.node.noPrompt = true;
+  }
+  if (userInput.hostServer) {
+    zssHost = userInput.hostServer;
+  }
+  if (userInput.port) {
+    if (!configJSON.node.http) { configJSON.node.http = {}; }
+    configJSON.node.http.port = userInput.port;
+  }
+  if (userInput.securePort && configJSON.node.https) {
+    configJSON.node.https.port = userInput.securePort;
+  }
+  if (userInput.noChild) {
+    configJSON.node.noChild = true;
+    delete configJSON.node.childProcesses;
+  }
+  allowInvalidTLS = (userInput.allowInvalidTLSProxy === 'true');
+} else {
   if (configJSON.agent) {
     if (configJSON.agent.https) {
       hostPort = configJSON.agent.https.port;
@@ -166,31 +190,28 @@ if (!hostPort) {
     } else {
       console.warn(`Invalid server configuration. Agent specified without http or https port`);
     }
+    if(configJSON.agent.host){
+      zssHost = configJSON.agent.host;
+    }
   } else if (configJSON.zssPort) {
     hostPort = configJSON.zssPort;
   }
-}
-if (userInput.hostServer) {
-  zssHost = userInput.hostServer;
-}
-if (userInput.port) {
-  if (!configJSON.node.http) { configJSON.node.http = {}; }
-  configJSON.node.http.port = userInput.port;
-}
-if (userInput.securePort && configJSON.node.https) {
-  configJSON.node.https.port = userInput.securePort;
-}
-if (userInput.noChild) {
-  delete configJSON.node.childProcesses;
+  if(configJSON.node.noChild === true){
+    delete configJSON.node.childProcesses;
+  }
+  if(configJSON.node.allowInvalidTLSProxy){
+    allowInvalidTLS = true;
+  }
+  console.log("Using config JSON, discarding CLI args");
 }
 const startUpConfig = {
   proxiedHost: zssHost,
   proxiedPort: hostPort,
-  allowInvalidTLSProxy: (userInput.allowInvalidTLSProxy === 'true')
+  allowInvalidTLSProxy: allowInvalidTLS
 };
 
 module.exports = function() {
-  return {appConfig: appConfig, configJSON: configJSON, startUpConfig: startUpConfig}
+  return {appConfig: appConfig, configJSON: configJSON, startUpConfig: startUpConfig, configLocation: userInput.config}
 }
 
 /*

--- a/lib/zluxCluster.js
+++ b/lib/zluxCluster.js
@@ -11,9 +11,9 @@
 'use strict';
 
 const clusterManager = require('zlux-server-framework/lib/clusterManager').clusterManager;
-const {appConfig, configJSON, startUpConfig} = require('./zluxArgs')();
+const {appConfig, configJSON, startUpConfig, configLocation} = require('./zluxArgs')();
 
-clusterManager.start(appConfig, configJSON, startUpConfig);
+clusterManager.start(appConfig, configJSON, startUpConfig, configLocation);
 
 //run as:
 //node --harmony zluxCluster.js --config=../deploy/instance/ZLUX/serverConfig/zluxserver.json -h <z/os system> -P <zssPort>

--- a/lib/zluxServer.js
+++ b/lib/zluxServer.js
@@ -13,8 +13,8 @@
 'use strict';
 const ProxyServer = require('zlux-server-framework');
 
-const {appConfig, configJSON, startUpConfig} = require('./zluxArgs')();
-const proxyServer = new ProxyServer(appConfig, configJSON, startUpConfig);
+const {appConfig, configJSON, startUpConfig, configLocation} = require('./zluxArgs')();
+const proxyServer = new ProxyServer(appConfig, configJSON, startUpConfig, configLocation);
 proxyServer.start().then(() => {
   console.log("started")
 }).catch(e => {


### PR DESCRIPTION
This pull request adds support for remapping server configuration.  The configLocation is exported from zluxArgs and consumed by the zluxCluster.js and zluxServer.js.  zluxArgs will no longer use CLI args if the config is rewritten (and the server reloaded).

Related:
https://github.com/zowe/zlux-server-framework/pull/137