### PR TITLE
Merge env var object into config

### DIFF
--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -108,6 +108,13 @@ if(process.env.overrideFileConfig !== "false"){
     console.log('Environment variables:\n'+JSON.stringify(process.env, null, 2));
     console.log('\nProcessing CLI arguments:\n'+commandArgs);
   }
+  const envConfig = argParser.environmentVarsToObject("ZWED_");
+  if (Object.keys(envConfig).length > 0) {
+    if (cluster.isMaster) {
+      console.log('\nProcessed environment variables:\n'+JSON.stringify(envConfig, null, 2));
+    }
+    configJSON = mergeUtils.deepAssign(configJSON, envConfig);
+  }
   if (userInput.D) {
     if (cluster.isMaster) {
       console.log('\nProcessed -D arguments:\n'+JSON.stringify(userInput.D, null, 2));

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -80,8 +80,36 @@ if (!userInput.config) {
   process.exit(-1);
 }
 let configJSON = DEFAULT_CONFIG;
+//Overall config is a result of a heirarchy of overrides from defaults.
+//CLI args > CLI -D arg > Env vars > JSON file > builtin defaults
 const userConfig = jsonUtils.parseJSONWithComments(userInput.config);
+//Config JSON overrides hardcoded defaults
 configJSON = mergeUtils.deepAssign(configJSON, userConfig);
+
+
+//Env overrides config JSON, -D args override env
+if(process.env.overrideFileConfig !== "false"){
+  if (cluster.isMaster) {
+    console.log('Environment variables:\n'+JSON.stringify(process.env, null, 2));
+    console.log('\nProcessing CLI arguments:\n'+commandArgs);
+  }
+  const envConfig = argParser.environmentVarsToObject("ZWED_");
+  if (Object.keys(envConfig).length > 0) {
+    if (cluster.isMaster) {
+      console.log('\nProcessed environment variables:\n'+JSON.stringify(envConfig, null, 2));
+    }
+    configJSON = mergeUtils.deepAssign(configJSON, envConfig);
+  }
+  if (userInput.D) {
+    if (cluster.isMaster) {
+      console.log('\nProcessed -D arguments:\n'+JSON.stringify(userInput.D, null, 2));
+    }
+    configJSON = mergeUtils.deepAssign(configJSON, userInput.D);
+  }
+} else {
+  console.log("Using config JSON, discarding CLI args");
+}
+
 if (configJSON.agent) {
   if (configJSON.agent.https) {
     agentPort = configJSON.agent.https.port;
@@ -103,25 +131,8 @@ if(configJSON.node.allowInvalidTLSProxy){
   allowInvalidTLS = true;
 }
 
+//finally, specific CLI flags override any above
 if(process.env.overrideFileConfig !== "false"){
-  if (cluster.isMaster) {
-    console.log('Environment variables:\n'+JSON.stringify(process.env, null, 2));
-    console.log('\nProcessing CLI arguments:\n'+commandArgs);
-  }
-  const envConfig = argParser.environmentVarsToObject("ZWED_");
-  if (Object.keys(envConfig).length > 0) {
-    if (cluster.isMaster) {
-      console.log('\nProcessed environment variables:\n'+JSON.stringify(envConfig, null, 2));
-    }
-    configJSON = mergeUtils.deepAssign(configJSON, envConfig);
-  }
-  if (userInput.D) {
-    if (cluster.isMaster) {
-      console.log('\nProcessed -D arguments:\n'+JSON.stringify(userInput.D, null, 2));
-    }
-    configJSON = mergeUtils.deepAssign(configJSON, userInput.D);
-  }
-
   let eUser = userInput.mlUser;
   let ePass = userInput.mlPass;
   if(eUser && ePass){
@@ -153,8 +164,6 @@ if(process.env.overrideFileConfig !== "false"){
     delete configJSON.node.childProcesses;
   }
   allowInvalidTLS = (userInput.allowInvalidTLSProxy === 'true');
-} else {
-  console.log("Using config JSON, discarding CLI args");
 }
 
 const startUpConfig = {


### PR DESCRIPTION
Utilizing the new functionality in https://github.com/zowe/zlux-server-framework/pull/156 to have env vars starting with ZWED_ or zwed_ to override what is in the JSON config file. CLI flags in turn override the env vars. However, env vars should not be read when doing a server dynamic reload, which only utilizes the content in the JSON.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>