### PR TITLE
More APIML configuration vars

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -18,6 +18,9 @@ then
 else
   NODE_BIN=node
 fi
+cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/bin
+. ./convert-env.sh
+
 cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/lib
 export NODE_PATH=../..:../../zlux-server-framework/node_modules:$NODE_PATH
 __UNTAGGED_READ_MODE=V6 $NODE_BIN initInstance.js

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -25,7 +25,7 @@ then
     export ZWED_node_mediationLayer_server_port=$DISCOVERY_PORT
   fi
 fi
-if [ -z "$ZWED_node_mediationLayer_server_hostname" ] 
+if [ -z "$ZWED_node_mediationLayer_server_hostname" ]
 then
   if [ -n "$ZOWE_EXPLORER_HOST" ]
   then
@@ -36,11 +36,26 @@ then
         *GATEWAY*)
           #All conditions met for app-server behind gateway: hostname, port, and component
           export ZWED_node_mediationLayer_enabled="true"
+          if [ "$APIML_ENABLE_SSO" = "true" ]; then
+            export ZWED_dataserviceAuthentication_implementationDefaults_apiml_plugins="org.zowe.zlux.auth.apiml,"
+          else
+            export ZWED_dataserviceAuthentication_implementationDefaults_apiml_plugins=","
+          fi
+          ;;
+        *)
+          export ZWED_node_mediationLayer_enabled="false"
+          export ZWED_dataserviceAuthentication_implementationDefaults_apiml_plugins=","
           ;;
       esac
     fi
   fi
 fi
+
+if [ -z "$ZWED_node_mediationLayer_enabled" ]
+then
+  export ZWED_node_mediationLayer_enabled="false"
+fi
+
 
 # certificates
 if [ -z "$ZWED_node_https_certificates" ]


### PR DESCRIPTION
Add more control over what the server should do when seeing apiml env vars. Enable/disable apiml-auth and discovery depending on env vars seen.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>