### PR TITLE
install-app fix and initinstance removal of ncp

### DIFF
--- a/bin/install-app.sh
+++ b/bin/install-app.sh
@@ -22,7 +22,17 @@ dir=$(cd `dirname $0` && pwd)
 if [ -e "${dir}/../instance.env" ]
 then
   . ${dir}/../instance.env
+  if [ -z "$INSTANCE_DIR" ]
+  then
+     export INSTANCE_DIR=$(cd "${dir}/.." && pwd)
+  fi
   zlux_path="$ROOT_DIR/components/app-server/share"
+  if [ ! -e "${INSTANCE_DIR}/workspace/app-server/serverConfig/server.json" ]
+  then
+    cd ${zlux_path}/zlux-app-server/lib
+    export NODE_PATH=../..:../../zlux-server-framework/node_modules:$NODE_PATH
+    __UNTAGGED_READ_MODE=V6 $NODE_BIN initInstance.js
+  fi
 elif [ -d "${dir}/../../zlux-server-framework" ]
 then
   zlux_path=$(cd $(dirname "$0")/../..; pwd)
@@ -36,6 +46,7 @@ app_path=$(cd "$1"; pwd)
 if [ $# -gt 1 ]
 then
   plugin_dir=$2
+  mkdir -p $plugin_dir
   shift
 fi
 shift

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -13,6 +13,8 @@ const path = require('path');
 const argParser = require('../../zlux-server-framework/utils/argumentParser');
 const jsonUtils = require('../../zlux-server-framework/lib/jsonUtils');
 const mergeUtils = require('../../zlux-server-framework/utils/mergeUtils');
+const os = require('os');
+const ncp = require('ncp').ncp;
 const { execSync } = require('child_process');
 const mkdirp = require('mkdirp');
 
@@ -172,9 +174,19 @@ try {
 }
 if (siteStorage.length == 0 && instanceStorage.length == 0) {
   console.log("Copying default plugin preferences into instance");
-  execSync("cp -r "+path.join(config.productDir, 'ZLUX', 'pluginStorage')+" "+path.join(config.instanceDir, 'ZLUX'));
-  execSync("chmod -R 750 "+instancePluginStorage);
-  process.exit(0);
+  if (os.platform() == 'win32') {
+    ncp(path.join(config.productDir, 'ZLUX', 'pluginStorage'), instancePluginStorage, function(err){
+      if (err) {
+        console.warn('Warning: error while copying plugin preferences into instance',err);
+        process.exit(1);
+      }
+      process.exit(0);
+    });
+  } else {
+    execSync("cp -r "+path.join(config.productDir, 'ZLUX', 'pluginStorage')+" "+path.join(config.instanceDir, 'ZLUX'));
+    execSync("chmod -R 750 "+instancePluginStorage);
+    process.exit(0);
+  }
 } else {
   process.exit(0);
 }

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -13,7 +13,7 @@ const path = require('path');
 const argParser = require('../../zlux-server-framework/utils/argumentParser');
 const jsonUtils = require('../../zlux-server-framework/lib/jsonUtils');
 const mergeUtils = require('../../zlux-server-framework/utils/mergeUtils');
-const ncp = require('ncp').ncp;
+const { execSync } = require('child_process');
 const mkdirp = require('mkdirp');
 
 const FOLDER_MODE = 0o0770 & (~process.umask());
@@ -172,13 +172,9 @@ try {
 }
 if (siteStorage.length == 0 && instanceStorage.length == 0) {
   console.log("Copying default plugin preferences into instance");
-  ncp(path.join(config.productDir, 'ZLUX', 'pluginStorage'), instancePluginStorage, function(err){
-    if (err) {
-      console.warn('Warning: error while copying plugin preferences into instance',err);
-      process.exit(1);
-    }
-    process.exit(0);
-  });
+  execSync("cp -r "+path.join(config.productDir, 'ZLUX', 'pluginStorage')+" "+path.join(config.instanceDir, 'ZLUX'));
+  execSync("chmod -R 750 "+instancePluginStorage);
+  process.exit(0);
 } else {
   process.exit(0);
 }


### PR DESCRIPTION
InitInstance fix for copying default settings, plus install-app fix for not needing server to run before use, and using instance_dir bugfix

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>