### PR TITLE
Patching README in staging branch from master to staging - (Solves - #363) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If using git, the following commands should be used:
 ```
 git clone --recursive git@github.com:zowe/zlux.git
 cd zlux
-git submodule foreach "git checkout master"
+git submodule foreach "git checkout staging"
 ```
 
 For the initial setup, the default authentication is the "trivial authentication" plugin, which allows login to the App Server without valid credentials. At the end of this guide, you can customize the environment to switch to a secure authentication plugin instead, such as the ZSS authentication plugin, covered in [Section 7](#7-adding-zss-to-the-environment).


### PR DESCRIPTION
Solves- https://github.com/zowe/zlux/issues/363
Currently, the documentation provided in the staging branch is less confusing to new users and developers.
But we get `file not found error` when following the steps 
This can be solved by checking out the `staging` branch rather than the `master` branch in the GitHub wiki 
Other solutions are also present