### PR TITLE
Remove use of ca by default to allow using no ca

### DIFF
--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -36,8 +36,7 @@ const DEFAULT_CONFIG = {
       "ipAddresses": ["0.0.0.0"],
       "port": 8544,
       "keys": ["../defaults/serverConfig/zlux.keystore.key"],
-      "certificates": ["../defaults/serverConfig/zlux.keystore.cer"],
-      "certificateAuthorities": ["../defaults/serverConfig/apiml-localca.cer"]
+      "certificates": ["../defaults/serverConfig/zlux.keystore.cer"]
     }
   },
   "dataserviceAuthentication": {


### PR DESCRIPTION
CA is not required in the case of self-signing, and therefore does not need to be there for the defaults which use self-signing. Having the defaults put into lib/zluxArgs.js means that it is difficult to not have any CA, so this removes that restriction.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>