### PR TITLE
Add default for x-frame

### DIFF
--- a/defaults/serverConfig/server.json
+++ b/defaults/serverConfig/server.json
@@ -18,9 +18,9 @@
       "enabled": false
     },
     "headers": {
-      "Content-Security-Policy": {
+      "X-frame-Options": {
         "override": true,
-        "preset": "strict"
+        "value": "sameorigin"
       }
     },
     "childProcesses": [

--- a/defaults/serverConfig/server.json
+++ b/defaults/serverConfig/server.json
@@ -17,6 +17,12 @@
       },
       "enabled": false
     },
+    "headers": {
+      "Content-Security-Policy": {
+        "override": true,
+        "preset": "strict"
+      }
+    },
     "childProcesses": [
       {
         "path": "../bin/zssServer.sh",


### PR DESCRIPTION
Use of https://github.com/zowe/zlux-server-framework/pull/180 to make it so that by default no plugins can be put into an iframe that is on a site outside the domain.
This needs testing: if this setting is wrong, content will not load properly in the browser.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>