### PR TITLE
Use 770 for instance file creation

### DIFF
--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -18,8 +18,8 @@ const ncp = require('ncp').ncp;
 const { execSync } = require('child_process');
 const mkdirp = require('mkdirp');
 
-const FOLDER_MODE = 0o0770 & (~process.umask());
-const FILE_MODE = 0o0770 & (~process.umask());
+const FOLDER_MODE = 0o0770;
+const FILE_MODE = 0o0770;
 
 
 
@@ -184,7 +184,7 @@ if (siteStorage.length == 0 && instanceStorage.length == 0) {
     });
   } else {
     execSync("cp -r "+path.join(config.productDir, 'ZLUX', 'pluginStorage')+" "+path.join(config.instanceDir, 'ZLUX'));
-    execSync("chmod -R 750 "+instancePluginStorage);
+    execSync("chmod -R 770 "+instancePluginStorage);
     process.exit(0);
   }
 } else {


### PR DESCRIPTION
Ignore umask if possible in order to avoid behavior that is out of the control of the code.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>