### PR TITLE
Advanced terminal config via env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 
 ## v1.16.0
 
-- Bugfix: Changes to terminal settings in instance.env would not take effect post-install, causing the initial values to be permenant unless users set personalized settings
+- Bugfix: Changes to terminal settings in instance.env would not take effect post-install, causing the initial values to be permenent unless users set personalized settings
 - Feature: More terminal settings present in the UI can be set as defaults from instance.env. TN3270 mod type can be set by ZOWE_ZLUX_TN3270_MOD, and the row and column by ZOWE_ZLUX_TN3270_ROW and ZOWE_ZLUX_TN3270_COL. ZOWE_ZLUX_TN3270_CODEPAGE also can be used to set the default codepage to a value which matches the strings seen in the UI, such as "278: Finnish/Swedish" for EBCDIC-278. As a shorthand, just the number can be set as well, such as "278".
 
 ## v1.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v1.16.0
+
+- Bugfix: Changes to terminal settings in instance.env would not take effect post-install, causing the initial values to be permenant unless users set personalized settings
+- Feature: More terminal settings present in the UI can be set as defaults from instance.env. TN3270 mod type can be set by ZOWE_ZLUX_TN3270_MOD, and the row and column by ZOWE_ZLUX_TN3270_ROW and ZOWE_ZLUX_TN3270_COL. ZOWE_ZLUX_TN3270_CODEPAGE also can be used to set the default codepage to a value which matches the strings seen in the UI, such as "278: Finnish/Swedish" for EBCDIC-278. As a shorthand, just the number can be set as well, such as "278".
+
 ## v1.13.0
 
 - Align app server's instance ID parameter to the Zowe Instance value

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -144,7 +144,7 @@ if (instanceItems.indexOf('org.zowe.configjs.json') == -1) {
   initUtils.registerBundledPlugins(config.pluginsDir, instancePluginStorage, instanceItems, FILE_MODE);
 }
 
-initUtils.setTerminalDefaults(instancePluginStorage);
+initUtils.setTerminalDefaults(instancePluginStorage, instanceItems);
   
 let siteStorage = [];
 let instanceStorage = [];

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -143,6 +143,8 @@ try {
 if (instanceItems.indexOf('org.zowe.configjs.json') == -1) {
   initUtils.registerBundledPlugins(config.pluginsDir, instancePluginStorage, instanceItems, FILE_MODE);
 }
+
+initUtils.setTerminalDefaults(instancePluginStorage);
   
 let siteStorage = [];
 let instanceStorage = [];

--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -86,19 +86,19 @@ module.exports.setTerminalDefaults = function(configDestination, instanceItems) 
         if (!isNaN(mod)) {
           tn3270Json.deviceType = ""+(mod-1);
         } else {
-          tn3270Json.deviceType = "1"; //80x24
+          tn3270Json.deviceType = "5"; //"dynamic"
         }
       }
       if (process.env['ZOWE_ZLUX_TN3270_ROW']) {
         let rowNum = Number(process.env['ZOWE_ZLUX_TN3270_ROW']);
         if (!isNaN(rowNum)) {
-          tn3270Json.alternateHeight = Math.min(Math.max(rowNum, 24),60);
+          tn3270Json.alternateHeight = Math.min(Math.max(rowNum, 24),80);
         }
       }
       if (process.env['ZOWE_ZLUX_TN3270_COL']) {
         let colNum = Number(process.env['ZOWE_ZLUX_TN3270_COL']);
         if (!isNaN(colNum)) {
-          tn3270Json.alternateWidth = Math.min(Math.max(colNum, 80),132);
+          tn3270Json.alternateWidth = Math.min(Math.max(colNum, 80),160);
         }
       }
       if (process.env['ZOWE_ZLUX_TN3270_CODEPAGE']) {

--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -57,20 +57,20 @@ module.exports.registerBundledPlugins = function(destination, configDestination,
   });  
 }
 
-module.exports.setTerminalDefaults = function(configDestination) {
-  if (process.env['ZOWE_ZLUX_SSH_PORT']) {
+module.exports.setTerminalDefaults = function(configDestination, instanceItems) {
+  if (instanceItems.indexOf('org.zowe.terminal.vt.json') != -1) {
     let defaultConfigDir = path.join(configDestination,'org.zowe.terminal.vt','sessions');
     mkdirp.sync(defaultConfigDir);
     try {
       fs.writeFileSync(path.join(defaultConfigDir,'_defaultVT.json'),
-                       JSON.stringify({host:"",
-                                       port: process.env['ZOWE_ZLUX_SSH_PORT'],
+                       JSON.stringify({host:process.env['ZOWE_ZLUX_SSH_HOST'] ? process.env['ZOWE_ZLUX_SSH_HOST'] : "",
+                                       port: process.env['ZOWE_ZLUX_SSH_PORT'] ? process.env['ZOWE_ZLUX_SSH_PORT'] : 22,
                                        security: {type: "ssh"}},null,2));
     } catch (e) {
       console.log('ZWED5016E - Could not customize vt-ng2, error writing json=',e);
     }
   }
-  if (process.env['ZOWE_ZLUX_TELNET_PORT']) {
+  if (instanceItems.indexOf('org.zowe.terminal.tn3270.json') != -1) {
     let security = 'telnet';
     if (process.env['ZOWE_ZLUX_SECURITY_TYPE']) {
       security = process.env['ZOWE_ZLUX_SECURITY_TYPE'];
@@ -78,10 +78,34 @@ module.exports.setTerminalDefaults = function(configDestination) {
     let defaultConfigDir = path.join(configDestination,'org.zowe.terminal.tn3270','sessions');
     mkdirp.sync(defaultConfigDir);
     try {
+      let tn3270Json = {host:process.env['ZOWE_ZLUX_TELNET_HOST'] ? process.env['ZOWE_ZLUX_TELNET_HOST'] : "",
+                        port: process.env['ZOWE_ZLUX_TELNET_PORT'] ? process.env['ZOWE_ZLUX_TELNET_PORT'] : 23,
+                        security: {type: security}};
+      if (process.env['ZOWE_ZLUX_TN3270_MOD']) {
+        let mod = Number(process.env['ZOWE_ZLUX_TN3270_MOD']);
+        if (!isNaN(mod)) {
+          tn3270Json.deviceType = ""+(mod-1);
+        } else {
+          tn3270Json.deviceType = "1"; //80x24
+        }
+      }
+      if (process.env['ZOWE_ZLUX_TN3270_ROW']) {
+        let rowNum = Number(process.env['ZOWE_ZLUX_TN3270_ROW']);
+        if (!isNaN(rowNum)) {
+          tn3270Json.alternateHeight = Math.min(Math.max(rowNum, 24),60);
+        }
+      }
+      if (process.env['ZOWE_ZLUX_TN3270_COL']) {
+        let colNum = Number(process.env['ZOWE_ZLUX_TN3270_COL']);
+        if (!isNaN(colNum)) {
+          tn3270Json.alternateWidth = Math.min(Math.max(colNum, 80),132);
+        }
+      }
+      if (process.env['ZOWE_ZLUX_TN3270_CODEPAGE']) {
+        tn3270Json.charsetName = process.env['ZOWE_ZLUX_TN3270_CODEPAGE'];
+      }
       fs.writeFileSync(path.join(defaultConfigDir,'_defaultTN3270.json'),
-                       JSON.stringify({host:"",
-                                       port: process.env['ZOWE_ZLUX_TELNET_PORT'],
-                                       security: {type: security}},null,2));
+                       JSON.stringify(tn3270Json));
     } catch (e) {
       console.log('ZWED5017E - Could not customize tn3270-ng2, error writing json=',e);
     }

--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -52,38 +52,40 @@ module.exports.registerBundledPlugins = function(destination, configDestination,
         fs.writeFileSync(path.join(destination,item),
                          JSON.stringify(newJson,null,2),
                          {encoding: 'utf8' , mode: filePermission});
-
-        //small hack for 2 terminals configuration
-        if (identifier == 'org.zowe.terminal.vt' && process.env['ZOWE_ZLUX_SSH_PORT']) {
-          let defaultConfigDir = path.join(configDestination,'org.zowe.terminal.vt','sessions');
-          mkdirp.sync(defaultConfigDir);
-          try {
-            fs.writeFileSync(path.join(defaultConfigDir,'_defaultVT.json'),
-                             JSON.stringify({host:"",
-                                             port: process.env['ZOWE_ZLUX_SSH_PORT'],
-                                             security: {type: "ssh"}},null,2));
-          } catch (e) {
-            console.log('ZWED5016E - Could not customize vt-ng2, error writing json=',e);
-          }
-        } else if (identifier == 'org.zowe.terminal.tn3270' && process.env['ZOWE_ZLUX_TELNET_PORT']) {
-          let security = 'telnet';
-          if (process.env['ZOWE_ZLUX_SECURITY_TYPE']) {
-            security = process.env['ZOWE_ZLUX_SECURITY_TYPE'];
-          }
-          let defaultConfigDir = path.join(configDestination,'org.zowe.terminal.tn3270','sessions');
-          mkdirp.sync(defaultConfigDir);
-          try {
-            fs.writeFileSync(path.join(defaultConfigDir,'_defaultTN3270.json'),
-                             JSON.stringify({host:"",
-                                             port: process.env['ZOWE_ZLUX_TELNET_PORT'],
-                                             security: {type: security}},null,2));
-          } catch (e) {
-            console.log('ZWED5017E - Could not customize tn3270-ng2, error writing json=',e);
-          }
-        }
       }
     }
   });  
+}
+
+module.exports.setTerminalDefaults = function(configDestination) {
+  if (process.env['ZOWE_ZLUX_SSH_PORT']) {
+    let defaultConfigDir = path.join(configDestination,'org.zowe.terminal.vt','sessions');
+    mkdirp.sync(defaultConfigDir);
+    try {
+      fs.writeFileSync(path.join(defaultConfigDir,'_defaultVT.json'),
+                       JSON.stringify({host:"",
+                                       port: process.env['ZOWE_ZLUX_SSH_PORT'],
+                                       security: {type: "ssh"}},null,2));
+    } catch (e) {
+      console.log('ZWED5016E - Could not customize vt-ng2, error writing json=',e);
+    }
+  }
+  if (process.env['ZOWE_ZLUX_TELNET_PORT']) {
+    let security = 'telnet';
+    if (process.env['ZOWE_ZLUX_SECURITY_TYPE']) {
+      security = process.env['ZOWE_ZLUX_SECURITY_TYPE'];
+    }
+    let defaultConfigDir = path.join(configDestination,'org.zowe.terminal.tn3270','sessions');
+    mkdirp.sync(defaultConfigDir);
+    try {
+      fs.writeFileSync(path.join(defaultConfigDir,'_defaultTN3270.json'),
+                       JSON.stringify({host:"",
+                                       port: process.env['ZOWE_ZLUX_TELNET_PORT'],
+                                       security: {type: security}},null,2));
+    } catch (e) {
+      console.log('ZWED5017E - Could not customize tn3270-ng2, error writing json=',e);
+    }
+  }
 }
 
 /* Warning: This function is unused and the way it works is subject to change */


### PR DESCRIPTION
Allow more env vars to configure terminals in more ways, and also post-install
The following new env vars would be supported in instance.env:
ZOWE_ZLUX_TELNET_HOST = string
ZOWE_ZLUX_SSH_HOST = string
ZOWE_ZLUX_TN3270_ROW = number
ZOWE_ZLUX_TN3270_COL = number
ZOWE_ZLUX_TN3270_MOD = numbers 2-5 as well as "dynamic" or other variations of the word
ZOWE_ZLUX_TN3270_CODEPAGE = ccsid number or string as seen in the ui


Resolves https://github.com/zowe/zowe-install-packaging/issues/1176
Resolves https://github.com/zowe/zowe-install-packaging/issues/1125

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>