### PR TITLE
Use instance number in jobname, and change unix process name to match…

### DIFF
--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -233,5 +233,16 @@ then
 else
   ZLUX_SERVER_FILE=zluxServer.js
 fi
-{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZOWE_PREFIX}DS1 ${NODE_BIN} --harmony ${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE
+
+if [ -z "$ZOWE_PREFIX" ]
+then
+  ZOWE_PREFIX="ZWE"
+fi
+if [ -z "$ZOWE_INSTANCE" ]
+then
+    ZOWE_INSTANCE="1"
+fi
+JOBNAME=${ZOWE_PREFIX}DS${ZOWE_INSTANCE}
+
+{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${JOBNAME} ${NODE_BIN} --harmony --title "${JOBNAME}" ${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE
 

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -244,5 +244,4 @@ then
 fi
 JOBNAME=${ZOWE_PREFIX}DS${ZOWE_INSTANCE}
 
-{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${JOBNAME} ${NODE_BIN} --harmony --title "${JOBNAME}" ${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE
-
+{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${JOBNAME} ${NODE_BIN} --harmony "${JOBNAME}" ${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -242,6 +242,6 @@ if [ -z "$ZOWE_INSTANCE" ]
 then
     ZOWE_INSTANCE="1"
 fi
-JOBNAME=${ZOWE_PREFIX}DS${ZOWE_INSTANCE}
+export ZLUX_JOBNAME=${ZOWE_PREFIX}DS${ZOWE_INSTANCE}
 
-{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${JOBNAME} ${NODE_BIN} --harmony "${JOBNAME}" ${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE
+{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZLUX_JOBNAME} ${NODE_BIN} --harmony ${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -18,7 +18,10 @@ const mergeUtils = require('zlux-server-framework/utils/mergeUtils');
 const mkdirp = require('mkdirp');
 const cluster = require('cluster');
 const PRODUCT_CODE = 'ZLUX';
-
+console.log('jobname='+process.env.ZLUX_JOBNAME);
+if (process.env.ZLUX_JOBNAME) {
+  process.title = ''+process.env.ZLUX_JOBNAME;
+}
 const DEFAULT_CONFIG = {
   "productDir":"../defaults",
   "siteDir":"../deploy/site",


### PR DESCRIPTION
I added a default value for ZOWE_INSTANCE & ZOWE_PREFIX because they don't exist in dev environments. They will in production, and these match those production defaults.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>