### PR TITLE
Update generate_zlux_certificates.sh

### DIFF
--- a/defaults/serverConfig/generate_zlux_certificates.sh
+++ b/defaults/serverConfig/generate_zlux_certificates.sh
@@ -14,8 +14,8 @@
 # You can execute it from any directory and it will update regenerate certificates for zLUX
 # in the same directory where the script is.
 #
-# It assumes that the `api-layer` repository is cloned at the same directory as `zlux`.
-# If it is different you need to set the `APIML_HOME` variable.
+# It assumes that the `api-layer` and `zowe-install-packaging` repositories are cloned at the same directory as `zlux`.
+# If it is different you need to set the `APIML_HOME` and `ZOWE_INSTALL_PACKAGING_HOME` variables.
 #
 
 BASE_DIR=$(dirname "$0")

--- a/defaults/serverConfig/generate_zlux_certificates.sh
+++ b/defaults/serverConfig/generate_zlux_certificates.sh
@@ -22,13 +22,16 @@ BASE_DIR=$(dirname "$0")
 if [ -z ${APIML_HOME+x} ]; then
     APIML_HOME="${BASE_DIR}/../../../../api-layer"
 fi
+if [ -z ${ZOWE_INSTALL_PACKAGING_HOME+x} ]; then
+    ZOWE_INSTALL_PACKAGING_HOME="${BASE_DIR}/../../../../zowe-install-packaging"
+fi
 
 SERVICE_KEYSTORE="${BASE_DIR}/zlux.keystore"
 SERVICE_TRUSTSTORE="${BASE_DIR}/zlux.truststore"
 SERVICE_DNAME="EMAILADDRESS=zowe-zlc@lists.openmainframeproject.org,CN=Zowe zLUX,O=Zowe,ST=California,C=US"
 LOCAL_CA_FILENAME="${APIML_HOME}/keystore/local_ca/localca"
 
-${APIML_HOME}/scripts/apiml_cm.sh --action new-service \
+${ZOWE_INSTALL_PACKAGING_HOME}/bin/apiml_cm.sh --action new-service \
   --local-ca-filename ${LOCAL_CA_FILENAME} --service-dname "${SERVICE_DNAME}" \
   --service-keystore ${SERVICE_KEYSTORE} --service-truststore ${SERVICE_TRUSTSTORE}
 


### PR DESCRIPTION
Update generate_zlux_certificates.sh because apiml_cm.sh has been moved into zowe-install-packaging repo.