### PR TITLE
Apiml handling cleanup

### DIFF
--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -36,26 +36,11 @@ then
         *GATEWAY*)
           #All conditions met for app-server behind gateway: hostname, port, and component
           export ZWED_node_mediationLayer_enabled="true"
-          if [ "$APIML_ENABLE_SSO" = "true" ]; then
-            export ZWED_dataserviceAuthentication_implementationDefaults_apiml_plugins="org.zowe.zlux.auth.apiml,"
-          else
-            export ZWED_dataserviceAuthentication_implementationDefaults_apiml_plugins=","
-          fi
-          ;;
-        *)
-          export ZWED_node_mediationLayer_enabled="false"
-          export ZWED_dataserviceAuthentication_implementationDefaults_apiml_plugins=","
           ;;
       esac
     fi
   fi
 fi
-
-if [ -z "$ZWED_node_mediationLayer_enabled" ]
-then
-  export ZWED_node_mediationLayer_enabled="false"
-fi
-
 
 # certificates
 if [ -z "$ZWED_node_https_certificates" ]

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -166,6 +166,12 @@ if(process.env.overrideFileConfig !== "false"){
   }
 }
 
+if (agentHost && agentPort) {
+  configJSON.agent = configJSON.agent || {};
+  configJSON.agent.host = agentHost;
+  configJSON.agent.http = configJSON.agent.http || {};
+  configJSON.agent.http.port = agentPort;
+}
 const startUpConfig = {
   proxiedHost: agentHost,
   proxiedPort: agentPort,


### PR DESCRIPTION
**Release note: Bugfix: app-server agent info was not available to plugins if it was specified via command line arguments**

Depends upon https://github.com/zowe/zlux-server-framework/pull/196

removed need to manage apiml inclusion or not, since it is redundant and that plugin will be replaced with sso auth. Added putting agent into configjson if specified over cli args


Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>