### PR TITLE
Update allowsPlugins list, remove apiml-auth default

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -24,33 +24,3 @@ cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/bin
 cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/lib
 export NODE_PATH=../..:../../zlux-server-framework/node_modules:$NODE_PATH
 __UNTAGGED_READ_MODE=V6 $NODE_BIN initInstance.js
-
-APP_WORKSPACE_DIR=${INSTANCE_DIR}/workspace/app-server
-
-if [[ $LAUNCH_COMPONENT_GROUPS == *"GATEWAY"* ]]; then
-  if [[ $APIML_ENABLE_SSO == "true" ]]; then
-    if [ ! -e "${APP_WORKSPACE_DIR}/plugins/org.zowe.zlux.auth.apiml.json" ]
-    then
-      cd ../bin
-      ./install-app.sh ${ROOT_DIR}/components/api-mediation/apiml-auth
-      # Activate the plugin
-      $NODE_BIN -e "let serverConfig = require('${APP_WORKSPACE_DIR}/serverConfig/server.json');\
- if (!serverConfig.dataserviceAuthentication.implementationDefaults.apiml) {\
- serverConfig.dataserviceAuthentication.implementationDefaults.apiml={plugins:['org.zowe.zlux.auth.apiml']};\
- const fs = require('fs');\
- fs.writeFileSync('${APP_WORKSPACE_DIR}/serverConfig/server.json', JSON.stringify(serverConfig, null, 2));\
-}"
-    fi
-  fi
-elif [ -e "${APP_WORKSPACE_DIR}/plugins/org.zowe.zlux.auth.apiml.json" ]
-then
-  rm "${APP_WORKSPACE_DIR}/plugins/org.zowe.zlux.auth.apiml.json"
-  # Remove plugin from config
-  $NODE_BIN -e "let serverConfig = require('${APP_WORKSPACE_DIR}/serverConfig/server.json');\
- if (serverConfig.dataserviceAuthentication.implementationDefaults.apiml) {\
- delete serverConfig.dataserviceAuthentication.implementationDefaults.apiml;\
- const fs = require('fs');\
- fs.writeFileSync('${APP_WORKSPACE_DIR}/serverConfig/server.json', JSON.stringify(serverConfig, null, 2));\
-}"
-fi
-     

--- a/defaults/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins/allowedPlugins.json
+++ b/defaults/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins/allowedPlugins.json
@@ -37,6 +37,12 @@
       ]
     },
     {
+      "identifier": "org.zowe.zlux.auth.safsso",
+      "versions": [
+        "*"
+      ]
+    },
+    {
       "identifier": "org.zowe.zlux.auth.trivial",
       "versions": [
         "*"
@@ -74,6 +80,12 @@
     },
     {
       "identifier": "org.zowe.zlux.ng2desktop.settings",
+      "versions": [
+        "*"
+      ]
+    },
+    {
+      "identifier": "org.zowe.zlux.ng2desktop.webbrowser",
       "versions": [
         "*"
       ]

--- a/defaults/serverConfig/server.json
+++ b/defaults/serverConfig/server.json
@@ -54,27 +54,7 @@
   "dataserviceAuthentication": {
     //this specifies the default authentication type for dataservices that didn't specify which type to use. These dataservices therefore should not expect a particular type of authentication to be used.
     "defaultAuthentication": "fallback",
-    "rbac": false,
-
-    //each authentication type may have more than one implementing plugin. define defaults and fallbacks below as well
-    //any types that have no implementers are ignored, and any implementations specified here that are not known to the server are also ignored.
-    "implementationDefaults": {
-      //each type has an object which describes which implementation to use based on some criteria to find which is best for the task. For now, just "plugins" will
-      //be used to state that you want a particular plugin.
-      //"zosmf": {
-      // zosmf plugin needs to be configured to target a zosmf instance. configure before using.
-      // "plugins": ["org.zowe.zlux.auth.zosmf"]
-      //},
-
-      "zss": {
-      // "plugins": ["org.zowe.zlux.auth.zss"]
-      },
-
-      "fallback": {
-        "plugins": ["org.zowe.zlux.auth.trivial"]
-      }
-      
-    }
+    "rbac": false
   },
   // Specifies the default language for the server framework logging
   "logLanguage": "en"

--- a/lib/upgradeInstance.js
+++ b/lib/upgradeInstance.js
@@ -10,26 +10,64 @@
 const fs = require('fs');
 const path = require('path');
 const semver = require('semver');
+const argParser = require('zlux-server-framework/utils/argumentParser');
 
 const versions = [
   {
     v: '1.11.0',
-    upgrade: function(toLocation, serverConfig, instanceItems) {
+    upgrade: function(toLocation, serverConfig, envConfig, instanceItems) {
+      let hasOutdatedZosmfPluginConfig = false;
       try {
-        let hasOutdatedZosmfPluginConfig = serverConfig.dataserviceAuthentication.implementationDefaults.zosmf
-            && !serverConfig.dataserviceAuthentication.implementationDefaults.zosmf.plugins;
-        if (hasOutdatedZosmfPluginConfig) {
+        hasOutdatedZosmfPluginConfig = serverConfig.dataserviceAuthentication.implementationDefaults.zosmf
+          && !serverConfig.dataserviceAuthentication.implementationDefaults.zosmf.plugins;
+      } catch (e) {
+        //change not needed
+      }
+
+      if (hasOutdatedZosmfPluginConfig) {
+        let pluginPath;
+        try {
           if (instanceItems.indexOf('org.zowe.zlux.auth.zosmf.json') != -1) {
             console.log('Removing org.zowe.zlux.auth.zosmf.json from defaults');
-            fs.unlinkSync(path.join(toLocation, 'plugins', 'org.zowe.zlux.auth.zosmf.json'));
+            pluginPath = path.join(toLocation, 'plugins', 'org.zowe.zlux.auth.zosmf.json');
+            fs.unlinkSync(pluginPath);
           }
           if (instanceItems.indexOf('org.zowe.zlux.proxy.zosmf.json') != -1) {
             console.log('Removing org.zowe.zlux.proxy.zosmf.json from defaults');
-            fs.unlinkSync(path.join(toLocation, 'plugins', 'org.zowe.zlux.proxy.zosmf.json'));
+            pluginPath = path.join(toLocation, 'plugins', 'org.zowe.zlux.proxy.zosmf.json');
+            fs.unlinkSync(pluginPath);
           }
+        } catch (e) {
+          console.warn(`Could not remove ${pluginPath}, error=${e.message}`);
+          throw e;
         }
+      }
+    }
+  },
+  {
+    v: '1.12.0',
+    upgrade: function(toLocation, serverConfig, envConfig, instanceItems) {
+      let hasOutdatedApimlPluginConfig = false;
+      try {
+        hasOutdatedApimlPluginConfig =
+          (serverConfig.dataserviceAuthentication.implementationDefaults.apiml
+            && (!serverConfig.dataserviceAuthentication.implementationDefaults.apiml.plugins
+              || (serverConfig.dataserviceAuthentication.implementationDefaults.apiml.plugins.length == 0)))
+          && !(envConfig.dataserviceAuthentication.implementationDefaults.apiml);
       } catch (e) {
         //change not needed
+      }
+      if (hasOutdatedApimlPluginConfig) {
+        if (instanceItems.indexOf('org.zowe.zlux.auth.apiml.json') != -1) {
+          console.log('Removing org.zowe.zlux.auth.apiml.json from defaults');
+          const pluginPath = path.join(toLocation, 'plugins', 'org.zowe.zlux.auth.apiml.json');
+          try {
+            fs.unlinkSync(pluginPath);
+          } catch (e) {
+            console.warn(`Could not remove ${pluginPath}, error=${e.message}`);
+            throw e;
+          }
+        }
       }
     }
   }
@@ -40,6 +78,7 @@ module.exports.doUpgrade = function doUpgrade(fromVersion, toLocation, serverCon
   let firstIndex = 0;
   let upgradingTo;
   let upgradedTo;
+  const envConfig = argParser.environmentVarsToObject("ZWED_");
   for (let i = 0; i < versions.length; i++) {
     if (semver.gt(versions[i].v, fromVersion)) {
       firstIndex = i;
@@ -49,13 +88,15 @@ module.exports.doUpgrade = function doUpgrade(fromVersion, toLocation, serverCon
   try {
     for (let i = firstIndex; i < versions.length; i++) {
       upgradingTo = versions[i].v;
-      versions[i].upgrade(toLocation, serverConfig, instanceItems);
+      versions[i].upgrade(toLocation, serverConfig, envConfig, instanceItems);
       upgradedTo = versions[i].v;
     }
   } catch (e) {
     console.log('app-server config could not upgrade to version='+upgradingTo);
   } finally {
-    console.log('app-server config upgraded to version='+upgradedTo);
+    if (!fromVersion == upgradedTo) {
+      console.log('app-server config upgraded to version='+upgradedTo);
+    }
     return upgradedTo;
   }
 };


### PR DESCRIPTION
Related to https://github.com/zowe/zowe-install-packaging/pull/1293
safsso plugin makes apiml-auth redundant, so it will be removed as a default to clean up the list.