### PR TITLE
Update bundled plugins upon ROOT_DIR change

### DIFF
--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -10,6 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const initUtils = require('./initUtils');
 const argParser = require('../../zlux-server-framework/utils/argumentParser');
 const jsonUtils = require('../../zlux-server-framework/lib/jsonUtils');
 const mergeUtils = require('../../zlux-server-framework/utils/mergeUtils');
@@ -112,56 +113,12 @@ try {
   console.warn("ZWED5003W - Warning: couldn't read plugin directory",e);
   //Couldnt read, will copy defaults
 }
-//Copy default plugins if could not find configjs - implies something wrong with environment.
-if (instanceItems.indexOf('org.zowe.configjs.json') == -1) {
-  let pluginsFolder = path.join(__dirname, '..', 'defaults', 'plugins');
-  let items = fs.readdirSync(pluginsFolder);
-  console.log('ZWED5011I - Generating default plugin references');
-  items.forEach(function (item) {
 
-    let itemPath = path.join(pluginsFolder, item);
-    if (! fs.lstatSync(itemPath).isDirectory() ){
-      let oldJson = JSON.parse(fs.readFileSync(itemPath), 'utf8');
-      const identifier = item.substring(0,item.length-5);
-      const location = path.isAbsolute(oldJson.pluginLocation)
-            ? oldJson.pluginLocation
-            : path.join(__dirname, '..', '..', oldJson.pluginLocation.substring(6)).replace(/\\/g,"\\\\");
-
-      fs.writeFileSync(path.join(config.pluginsDir,item),
-                       '{"identifier":"'+identifier
-                       +'",\n"pluginLocation":"'+location
-                       +'"}', {encoding: 'utf8' , mode: FILE_MODE});
-
-      //small hack for 2 terminals configuration
-      if (identifier == 'org.zowe.terminal.vt' && process.env['ZOWE_ZLUX_SSH_PORT']) {
-        let defaultConfigDir = path.join(instancePluginStorage,'org.zowe.terminal.vt','sessions');
-        mkdirp.sync(defaultConfigDir);
-        try {
-          fs.writeFileSync(path.join(defaultConfigDir,'_defaultVT.json'),
-                           JSON.stringify({host:"",
-                                           port: process.env['ZOWE_ZLUX_SSH_PORT'],
-                                           security: {type: "ssh"}},null,2));
-        } catch (e) {
-          console.log('ZWED5016E - Could not customize vt-ng2, error writing json=',e);
-        }
-      } else if (identifier == 'org.zowe.terminal.tn3270' && process.env['ZOWE_ZLUX_TELNET_PORT']) {
-        let security = 'telnet';
-        if (process.env['ZOWE_ZLUX_SECURITY_TYPE']) {
-          security = process.env['ZOWE_ZLUX_SECURITY_TYPE'];
-        }
-        let defaultConfigDir = path.join(instancePluginStorage,'org.zowe.terminal.tn3270','sessions');
-        mkdirp.sync(defaultConfigDir);
-        try {
-          fs.writeFileSync(path.join(defaultConfigDir,'_defaultTN3270.json'),
-                           JSON.stringify({host:"",
-                                           port: process.env['ZOWE_ZLUX_TELNET_PORT'],
-                                           security: {type: security}},null,2));
-        } catch (e) {
-          console.log('ZWED5017E - Could not customize tn3270-ng2, error writing json=',e);
-        }
-      }
-    }
-  });
+//Update bundled plugins in the case that they are missing or are outdated from a previous install
+//Use org.zowe.configjs as indication of if they are missing or not
+const lastServerRoot = initUtils.getLastZoweRoot(workspaceLocation);
+if ((lastServerRoot != process.env.ROOT_DIR) || (instanceItems.indexOf('org.zowe.configjs.json') == -1)) {
+  initUtils.registerBundledPlugins(config.pluginsDir, instancePluginStorage, lastServerRoot, instanceItems, FILE_MODE);
 }
 
 let siteStorage = [];

--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -1,0 +1,107 @@
+/*
+ This program and the accompanying materials are
+ made available under the terms of the Eclipse Public License v2.0 which accompanies
+ this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+ SPDX-License-Identifier: EPL-2.0
+
+ Copyright Contributors to the Zowe Project.
+*/
+
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+
+module.exports.registerBundledPlugins = function(destination, configDestination, oldRootDir,
+                                                 oldPlugins, filePermission) {
+  let pluginsFolder = path.join(__dirname, '..', 'defaults', 'plugins');
+  let items = fs.readdirSync(pluginsFolder);
+  console.log('ZWED5011I - Generating default plugin references');
+  items.forEach(function (item) {
+    let itemPath = path.join(pluginsFolder, item);
+    let defaultJson = JSON.parse(fs.readFileSync(itemPath), 'utf8');
+    const location = path.isAbsolute(defaultJson.pluginLocation)
+          ? defaultJson.pluginLocation
+          : path.join(__dirname, '..', '..', defaultJson.pluginLocation.substring(6)).replace(/\\/g,"\\\\");
+    
+    if (! fs.lstatSync(itemPath).isDirectory() ){
+      let keepOldJson = false;
+      try {
+        if (oldPlugins.indexOf(item) != -1) {
+          let oldLocation = JSON.parse(fs.readFileSync(path.join(destination,item))).pluginLocation;
+          //if its identical, dont rewrite the file
+          //if the old plugin didnt come from the old root, this must have been user preference, don't change it!
+          if (oldLocation == location
+             || !oldLocation.startsWith(oldRootDir)) {
+            keepOldJson = true;
+          }
+        }
+      } catch (e) {
+        console.warn('Error reading old plugin reference in workspace folder, leaving unchanged.');
+        keepOldJson = true;
+      }
+
+      if (!keepOldJson) {
+        const identifier = item.substring(0,item.length-5);
+
+        fs.writeFileSync(path.join(destination,item),
+                         '{"identifier":"'+identifier
+                         +'",\n"pluginLocation":"'+location
+                         +'"}', {encoding: 'utf8' , mode: filePermission});
+
+        //small hack for 2 terminals configuration
+        if (identifier == 'org.zowe.terminal.vt' && process.env['ZOWE_ZLUX_SSH_PORT']) {
+          let defaultConfigDir = path.join(configDestination,'org.zowe.terminal.vt','sessions');
+          mkdirp.sync(defaultConfigDir);
+          try {
+            fs.writeFileSync(path.join(defaultConfigDir,'_defaultVT.json'),
+                             JSON.stringify({host:"",
+                                             port: process.env['ZOWE_ZLUX_SSH_PORT'],
+                                             security: {type: "ssh"}},null,2));
+          } catch (e) {
+            console.log('ZWED5016E - Could not customize vt-ng2, error writing json=',e);
+          }
+        } else if (identifier == 'org.zowe.terminal.tn3270' && process.env['ZOWE_ZLUX_TELNET_PORT']) {
+          let security = 'telnet';
+          if (process.env['ZOWE_ZLUX_SECURITY_TYPE']) {
+            security = process.env['ZOWE_ZLUX_SECURITY_TYPE'];
+          }
+          let defaultConfigDir = path.join(configDestination,'org.zowe.terminal.tn3270','sessions');
+          mkdirp.sync(defaultConfigDir);
+          try {
+            fs.writeFileSync(path.join(defaultConfigDir,'_defaultTN3270.json'),
+                             JSON.stringify({host:"",
+                                             port: process.env['ZOWE_ZLUX_TELNET_PORT'],
+                                             security: {type: security}},null,2));
+          } catch (e) {
+            console.log('ZWED5017E - Could not customize tn3270-ng2, error writing json=',e);
+          }
+        }
+      }
+    }
+  });  
+}
+
+module.exports.getLastZoweRoot = function(workspaceLocation) {
+  try {
+    const backupsDirContent = fs.readdirSync(path.join(workspaceLocation, 'backups'));
+    if (backupsDirContent.length == 0) {return null;}
+    let lastBackup = backupsDirContent[0];
+    backupsDirContent.forEach((backup)=> {
+      if (backup > lastBackup) {
+        lastBackup = backup;
+      }
+    });
+    const lines = fs.readFileSync(path.join(workspaceLocation, 'backups', lastBackup),'utf8').split('\n');
+    for (let i = 0; i < lines.length; i++) {
+      if (lines[i].startsWith('ROOT_DIR=')) {
+        /*ex: ROOT_DIR=/opt/zowe/zowe-1.11.0 */
+        return lines[i].substr(9);
+      }
+    }
+  } catch (e) {
+    console.warn('Could not read workspace backup directory, previous Zowe version unknown');
+    return null;
+  }
+  return null;//dev environment with no env files in backups?
+}


### PR DESCRIPTION
In the development situation where your ROOT_DIR changes, currently plugin references are not updated because the code does not have a way to determine if the references are coming from outside of the current ROOT_DIR simply because they are outdated or because they have been altered by explicit end user configuration.

With this change, the code reads the workspace backup folder to see the history of previous ROOT_DIR values. If ROOT_DIR changes since last run, then inspection determines if the locations of plugins are up-to-date with respect to the new ROOT_DIR or not.
If plugins currently registered come from the old ROOT_DIR, they are replaced. If they are already from the new ROOT_DIR, or come from a different place, then they are not touched.

How can you tell this is working? Look at the "location" attribute of the JSON files within $INSTANCE_DIR/workspace/app-server/plugins before-and-after changing the ROOT_DIR of an environment. You should see that if the code detects a difference, `ZWED5011I - Generating default plugin references` is printed and the replacement occurs.
With testing, it's a good idea to explicitly change the location of a plugin to a 3rd and unrelated place, rather than coming from within the current ROOT_DIR or the old ROOT_DIR. If it remains unchanged, it's proof that this pull request will not destroy references to 3rd party plugins.

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>