### PR TITLE
Don't print PASSWORD and SECRET environment variables at startup

### DIFF
--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -85,11 +85,24 @@ const userConfig = jsonUtils.parseJSONWithComments(userInput.config);
 //Config JSON overrides hardcoded defaults
 configJSON = mergeUtils.deepAssign(configJSON, userConfig);
 
+function getSafeToPrintEnvironment(env) {
+  const keys = Object.keys(env).filter(key => {
+    const upperCasedKey = key.toUpperCase();
+    if (upperCasedKey.indexOf('PASSWORD') != -1 || upperCasedKey.indexOf('SECRET') != -1) {
+      return false;
+    }
+    return true;
+  });
+  const safeEnvironment = {};
+  keys.forEach(key => safeEnvironment[key] = env[key]);
+  return safeEnvironment;
+}
 
 //Env overrides config JSON, -D args override env
 if(process.env.overrideFileConfig !== "false"){
   if (cluster.isMaster) {
-    console.log('ZWED5013I - Environment variables:\n'+JSON.stringify(process.env, null, 2));
+    const safeEnvironment = getSafeToPrintEnvironment(process.env);
+    console.log('ZWED5013I - Environment variables:\n'+JSON.stringify(safeEnvironment, null, 2));
     console.log('\nZWED5014I - Processing CLI arguments:\n'+commandArgs);
   }
   const envConfig = argParser.environmentVarsToObject("ZWED_");


### PR DESCRIPTION
Don't print at startup environment variables that contain PASSWORD or SECRET.