### PR TITLE
Use external root ca, if it exists

### DIFF
--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -64,7 +64,7 @@ then
   elif [ -n "$KEYSTORE_CERTIFICATE_AUTHORITY" ]
   then
     #, at end turns it into an array
-    export ZWED_node_https_certificateAuthorities=$KEYSTORE_CERTIFICATE_AUTHORITY,
+    export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA}
   fi
 fi
 if [ -z "$ZWED_node_https_keys" ]


### PR DESCRIPTION
Makes use of https://github.com/zowe/zowe-install-packaging/pull/1413 to enable the app server to use more than one CA.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>