### PR TITLE
Align instance ID when it is non-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
-## Recent Changes
+## v1.13.0
+
+- Align app server's instance ID parameter to the Zowe Instance value
+
+## v1.12.0
 
 - Add v1.12 update script for replacing all bundled plugin references with ones that use $ROOT_DIR environment variable
 - Change Scripts to work with independent zss component

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -7,6 +7,15 @@
 #
 # Copyright Contributors to the Zowe Project.
 
+# For backwards compatible behavior, only set the instance ID if it is non-default
+if [ -n "$ZOWE_INSTANCE" ]
+then
+    if [ "$ZOWE_INSTANCE" != "1" ]
+    then
+        export ZWED_instanceID=$ZOWE_INSTANCE
+    fi
+fi
+
 # shape old env vars into app-server compatible ones
 # mediation layer
 if [ -z "$ZWED_node_mediationLayer_server_gatewayPort" ]


### PR DESCRIPTION
InstanceID parameter within the server predates the environment variable, but is used by few. Primarily, it was used for RBAC resource naming. Therefore, to not disturb pre-existing ones, the server should only use the environment variable if it is non-default, since the env default is "1" while the app server's default was "0".
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>