### PR TITLE
Write install json without nodejs

### DIFF
--- a/bin/install-app.sh
+++ b/bin/install-app.sh
@@ -17,8 +17,20 @@ then
 else
   NODE_BIN=node
 fi
-export _BPXK_AUTOCVT=ON
 
+setVars() {
+  export _CEE_RUNOPTS="FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
+  export _TAG_REDIR_IN=txt
+  export _TAG_REDIR_OUT=txt
+  export _TAG_REDIR_ERR=txt
+  export _BPXK_AUTOCVT="ON"
+
+  export _EDC_ADD_ERRNO2=1                        # show details on error
+  unset ENV             # just in case, as it can cause unexpected output
+  umask 0002                                       # similar to chmod 755
+
+  export __UNTAGGED_READ_MODE=V6
+}
 
 dir=$(cd `dirname $0` && pwd)
 if [ -e "${dir}/../instance.env" ]
@@ -27,6 +39,8 @@ then
   if [ -e "$ROOT_DIR/bin/internal/zowe-set-env.sh" ]
   then
     . ${ROOT_DIR}/bin/internal/zowe-set-env.sh
+  else
+    setVars
   fi
   if [ -z "$INSTANCE_DIR" ]
   then
@@ -42,9 +56,11 @@ then
 elif [ -d "${dir}/../../zlux-server-framework" ]
 then
   zlux_path=$(cd $(dirname "$0")/../..; pwd)
+  setVars
 elif [ -n "$CONDA_PREFIX" ]
 then
   zlux_path="$CONDA_PREFIX/share/zowe/app-server"
+  setVars
 fi
 
 utils_path=$zlux_path/zlux-server-framework/utils


### PR DESCRIPTION
Add option to write the json file without using nodejs.
This shouldn't be needed for most, but we've seen in one case a seemingly nodejs-releated issue with running the app install, yet the same nodejs did not have an issue running zowe itself.
While that sounds strange, this did allow us to successfully install apps, so this is a backup option hidden with an environment variable.

This actually is useful in the case you want to install a zss plugin without having nodejs.

Testing:
```
> ./install-app.sh ~/zlux-editor
Testing if node exists
node is /usr/local/bin/node
Running app-server plugin installer. Log=/dev/null
utils_path=~/zlux-server-framework/utils
app_path=~/zlux-editor
json_path=/home/sgrady/.zowe/workspace/app-server/serverConfig/server.json
2020-09-08 22:28:50.987 <ZWED:1660> sgrady INFO (_zsf.utils,util.js:288) ZWED0051I ~/zlux-editor ~/zlux-editor
2020-09-08 22:28:50.989 <ZWED:1660> sgrady INFO (_zsf.utils,util.js:288) ZWED0051I /home/sgrady/.zowe/workspace/app-server/serverConfig/server.json /home/sgrady/.zowe/workspace/app-server/serverConfig/server.json
2020-09-08 22:28:50.990 <ZWED:1660> sgrady INFO (_zsf.utils,util.js:288) ZWED0051I /home/sgrady/.zowe/workspace/app-server/plugins /home/sgrady/.zowe/workspace/app-server/plugins
2020-09-08 22:28:50.991  ZWED0109I - Registering App (ID=org.zowe.editor) with App Server
2020-09-08 22:28:50.996  ZWED0110I - App org.zowe.editor installed to ~/zlux-editor and registered with App Server
Ended with rc=0

(case when i was missing content)
> INSTALL_NO_NODE=1 ./install-app.sh ~/zlux-editor
NodeJS not found or not requested, attempting fallback plugin install behavior
Found plugin=org.zowe.editor
./install-app.sh: 100: ./install-app.sh: cannot create /workspace/app-server/plugins/org.zowe.editor.json: Directory nonexistent
Ended with rc=2

> INSTALL_NO_NODE=1 ./install-app.sh ~/zlux-editor
NodeJS not found or not requested, attempting fallback plugin install behavior
Found plugin=org.zowe.editor
Ended with rc=0

> export PATH=/bin:/sbin
> ./install-app.sh ~/zlux-editor
./install-app.sh: 1: ./install-app.sh: dirname: not found
./install-app.sh: 81: cd: can't cd to /sgrady/miniconda3/share/zowe/app-server/zlux-app-server/bin
Testing if node exists
node: not found
NodeJS not found or not requested, attempting fallback plugin install behavior
Found plugin=org.zowe.editor
Ended with rc=0
```

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>