### PR TITLE
Add external CA certs to app-server CA array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
-## v1.16.0
+## v1.17.0
 
 - Bugfix: make use of external certificate authorities referenced during keystore setup time
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Zlux App Server package will be documented in this fi
 
 ## v1.16.0
 
+- Bugfix: make use of external certificate authorities referenced during keystore setup time
+
+## v1.16.0
+
 - Bugfix: Changes to terminal settings in instance.env would not take effect post-install, causing the initial values to be permenent unless users set personalized settings
 - Feature: More terminal settings present in the UI can be set as defaults from instance.env. TN3270 mod type can be set by ZOWE_ZLUX_TN3270_MOD, and the row and column by ZOWE_ZLUX_TN3270_ROW and ZOWE_ZLUX_TN3270_COL. ZOWE_ZLUX_TN3270_CODEPAGE also can be used to set the default codepage to a value which matches the strings seen in the UI, such as "278: Finnish/Swedish" for EBCDIC-278. As a shorthand, just the number can be set as well, such as "278".
 

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -79,7 +79,7 @@ then
     #, at end turns it into an array
     if [ -n "$EXTERNAL_CERTIFICATE_AUTHORITIES" ]
     then
-      export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},${$EXTERNAL_CERTIFICATE_AUTHORITIES// /,}
+      export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},$(echo "$KEYSTORE_CERTIFICATE_AUTHORITY" | tr " " ",")
     else
       export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},
     fi

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -65,7 +65,7 @@ then
   elif [ -n "$KEYSTORE_CERTIFICATE" ]
   then
     #, at end turns it into an array
-    export ZWED_node_https_certificates=$KEYSTORE_CERTIFICATE,$KEYSTORE,
+    export ZWED_node_https_certificates=$KEYSTORE_CERTIFICATE,
   fi
 fi
 if [ -z "$ZWED_node_https_certificateAuthorities" ]
@@ -77,7 +77,12 @@ then
   elif [ -n "$KEYSTORE_CERTIFICATE_AUTHORITY" ]
   then
     #, at end turns it into an array
-    export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},$KEYSTORE,
+    if [ -n "$EXTERNAL_CERTIFICATE_AUTHORITIES" ]
+    then
+      export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},${$EXTERNAL_CERTIFICATE_AUTHORITIES// /,}
+    else
+      export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},
+    fi
   fi
 fi
 if [ -z "$ZWED_node_https_keys" ]

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -65,7 +65,7 @@ then
   elif [ -n "$KEYSTORE_CERTIFICATE" ]
   then
     #, at end turns it into an array
-    export ZWED_node_https_certificates=$KEYSTORE_CERTIFICATE,
+    export ZWED_node_https_certificates=$KEYSTORE_CERTIFICATE,$KEYSTORE,
   fi
 fi
 if [ -z "$ZWED_node_https_certificateAuthorities" ]
@@ -77,7 +77,7 @@ then
   elif [ -n "$KEYSTORE_CERTIFICATE_AUTHORITY" ]
   then
     #, at end turns it into an array
-    export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA}
+    export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},$KEYSTORE,
   fi
 fi
 if [ -z "$ZWED_node_https_keys" ]

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -79,7 +79,7 @@ then
     #, at end turns it into an array
     if [ -n "$EXTERNAL_CERTIFICATE_AUTHORITIES" ]
     then
-      export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},$(echo "$KEYSTORE_CERTIFICATE_AUTHORITY" | tr " " ",")
+      export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},$(echo "$EXTERNAL_CERTIFICATE_AUTHORITIES" | tr " " ",")
     else
       export ZWED_node_https_certificateAuthorities=${KEYSTORE_CERTIFICATE_AUTHORITY},${EXTERNAL_ROOT_CA},
     fi


### PR DESCRIPTION
DO NOT MERGE WITHOUT:
https://github.com/zowe/zowe-install-packaging/pull/1742

Related:
https://github.com/zowe/zlux-server-framework/pull/254

This pull request fixes the following bug:
- External certificate authorities are not registered with the app server properly and may contribute to a SELF_SIGNED_CERT_IN_CHAIN error when using the mediation layer.

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>