### PR TITLE
Fix case where server would end up with no plugins

### DIFF
--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -132,16 +132,24 @@ function generateComponentJson() {
 }
 
 
-let instanceItems = [];
-try {
-  instanceItems = fs.readdirSync(config.pluginsDir);
-} catch (e) {
-  console.warn("ZWED5003W - Warning: couldn't read plugin directory",e);
-  //Couldnt read, will copy defaults
+function getPluginJsonNames() {
+  try {
+    return fs.readdirSync(config.pluginsDir);
+  } catch (e) {
+    console.warn("ZWED5003W - Warning: couldn't read plugin directory",e);
+  }
+  return [];
 }
+
+let instanceItems = getPluginJsonNames();
 //Copy default plugins if could not find configjs - implies something wrong with environment.
 if (instanceItems.indexOf('org.zowe.configjs.json') == -1) {
   initUtils.registerBundledPlugins(config.pluginsDir, instancePluginStorage, instanceItems, FILE_MODE);
+  instanceItems = getPluginJsonNames();
+  if (instanceItems.indexOf('org.zowe.configjs.json') == -1) {
+    console.warn('ZWED0156E - Could not register default plugins into app-server');
+    process.exit(1);
+  }
 }
 
 initUtils.setTerminalDefaults(instancePluginStorage, instanceItems);


### PR DESCRIPTION
New code to handle terminal settings was given a list of plugins that was based on the initial state of when configuration was run.
If the list is empty, default plugins get registered which should result in the list containing those plugins, but this list did not get updated, so there was a state for configuration in which terminal settings were not set as a result.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>