### PR TITLE
Enable app-server working directory to be configurable

### DIFF
--- a/bin/app-server.bat
+++ b/bin/app-server.bat
@@ -90,6 +90,8 @@ if defined ZLUX_NODE_LOG_FILE (
 cd %temp_cd%
 
 cd ..\lib
+set ZOWE_LIB_DIR=%CD%
+
 if not defined ZLUX_MIN_WORKERS (
   set ZLUX_MIN_WORKERS=2
 )
@@ -101,14 +103,21 @@ if "%ZLUX_NO_CLUSTER%" == "1" (
   set ZLUX_SERVER_FILE=zluxCluster.js
 )
 
+if not defined ZOWE_WORKING_DIR (
+  set ZOWE_WORKING_DIR=!ZOWE_LIB_DIR!
+) else (
+   echo Server is about to start with a non default working directory. Working dir=!ZOWE_WORKING_DIR!
+)
+
 REM Check if print to terminal argument exists
 echo.%* | findstr /C:"--logToTerminal" 1>nul
+cd !ZOWE_WORKING_DIR!
 if errorlevel 1 (
   echo Server startup. Log location=!ZLUX_LOG_PATH!
-  !NODE_BIN! --harmony !ZLUX_SERVER_FILE! --config="!CONFIG_FILE!" %* > "!ZLUX_LOG_PATH!" 2>&1
+  !NODE_BIN! --harmony !ZOWE_LIB_DIR!\!ZLUX_SERVER_FILE! --config="!CONFIG_FILE!" %* > "!ZLUX_LOG_PATH!" 2>&1
 ) ELSE (
   echo Server startup. Logging to terminal...
-  !NODE_BIN! --harmony !ZLUX_SERVER_FILE! --config="!CONFIG_FILE!" %*
+  !NODE_BIN! --harmony !ZOWE_LIB_DIR!\!ZLUX_SERVER_FILE! --config="!CONFIG_FILE!" %*
 )
 set rc=%ERRORLEVEL%
 echo Ended with rc=%rc%

--- a/bin/app-server.bat
+++ b/bin/app-server.bat
@@ -106,7 +106,7 @@ if "%ZLUX_NO_CLUSTER%" == "1" (
 if not defined ZOWE_WORKING_DIR (
   set ZOWE_WORKING_DIR=!ZOWE_LIB_DIR!
 ) else (
-   echo Server is about to start with a non default working directory. Working dir=!ZOWE_WORKING_DIR!
+   echo Server is about to start with a non default working directory. Working dir=!ZOWE_WORKING_DIR! 
 )
 
 REM Check if print to terminal argument exists

--- a/bin/app-server.bat
+++ b/bin/app-server.bat
@@ -106,7 +106,7 @@ if "%ZLUX_NO_CLUSTER%" == "1" (
 if not defined ZOWE_WORKING_DIR (
   set ZOWE_WORKING_DIR=!ZOWE_LIB_DIR!
 ) else (
-   echo Server is about to start with a non default working directory. Working dir=!ZOWE_WORKING_DIR! 
+   echo Server is about to start with a non default working directory. Working dir=!ZOWE_WORKING_DIR!
 )
 
 REM Check if print to terminal argument exists

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -231,6 +231,8 @@ else
   echo "Server is about to start with a non default working directory. Working dir=$ZOWE_WORKING_DIR"
 fi
 
+echo "BIG TEST"
+
 cd $ZOWE_WORKING_DIR
 
 echo Starting node

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -209,6 +209,9 @@ then
   ZLUX_NODE_LOG_FILE=/dev/null
 fi
 
+export ZOWE_LIB_DIR=$dir/../lib
+echo $ZOWE_LIB_DIR
+
 #Determined log file.  Run node appropriately.
 cd $dir
 export NODE_PATH=../..:../../zlux-server-framework/node_modules:$NODE_PATH
@@ -221,6 +224,14 @@ env
 echo Show location of node
 type node
 
+if [ -z "$ZOWE_WORKING_DIR" ]
+then
+  export ZOWE_WORKING_DIR=$ZOWE_LIB_DIR
+else
+  echo "Server is about to start with a non default working directory. Working dir=$ZOWE_WORKING_DIR"
+fi
+
+cd $ZOWE_WORKING_DIR
 
 echo Starting node
 if [ -z "$ZLUX_NO_CLUSTER" ]
@@ -233,5 +244,5 @@ then
 else
   ZLUX_SERVER_FILE=zluxServer.js
 fi
-{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZOWE_PREFIX}DS1 ${NODE_BIN} --harmony ${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE
+{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZOWE_PREFIX}DS1 ${NODE_BIN} --harmony ${ZOWE_LIB_DIR}/${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE
 

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -209,13 +209,12 @@ then
   ZLUX_NODE_LOG_FILE=/dev/null
 fi
 
-export ZOWE_LIB_DIR=$dir/../lib
-echo $ZOWE_LIB_DIR
-
 #Determined log file.  Run node appropriately.
 cd $dir
 export NODE_PATH=../..:../../zlux-server-framework/node_modules:$NODE_PATH
 cd ../lib
+
+export ZOWE_LIB_DIR=$(cd `dirname $0` && pwd)
 
 export "_CEE_RUNOPTS=XPLINK(ON),HEAPPOOLS(ON)"
 

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -231,8 +231,6 @@ else
   echo "Server is about to start with a non default working directory. Working dir=$ZOWE_WORKING_DIR"
 fi
 
-echo "BIG TEST"
-
 cd $ZOWE_WORKING_DIR
 
 echo Starting node


### PR DESCRIPTION
This pull request implements the following feature:
- Allow the app-server working directory to be configured via environment variable. By default, the current working directory is ${zlux-app-server component dir}/lib which may be read only in some cases.

Signed-off-by: Timothy Gerstel <tgerstel@rocketsoftware.com>