### PR TITLE
Fix missing file that was renamed

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -14,6 +14,6 @@
 # - NODE_HOME
 cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/bin
 . ./convert-env.sh
-. ./set-node.sh
+. ./internal-node-init.sh
 cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/lib
 __UNTAGGED_READ_MODE=V6 $NODE_BIN initInstance.js


### PR DESCRIPTION
From https://github.com/zowe/zlux-app-server/pull/144 there was one reference to set-node that was not updated, causing failure.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>