### PR TITLE
Automate TLS setup for zss

### DIFF
--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -176,7 +176,7 @@ then
   then
     if [ -n "$ZOWE_ZSS_SERVER_PORT" ]
     then
-      export ZWED_agent_http_port=$ZOWE_ZSS_SERVER_PORT
+      export "ZWED_agent_http_port=$ZOWE_ZSS_SERVER_PORT"
     fi
   fi
 else
@@ -185,7 +185,7 @@ else
   then
     if [ -n "$ZOWE_ZSS_SERVER_PORT" ]
     then
-      export ZWED_agent_https_port=$ZOWE_ZSS_SERVER_PORT
+      export "ZWED_agent_https_port=$ZOWE_ZSS_SERVER_PORT"
     fi
   fi
   if [ -z "$ZWED_agent_host" ]

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -169,11 +169,28 @@ then
 fi
 
 # zss
-if [ -z "$ZWED_agent_https_port" ]
+if [ "$ZOWE_ZSS_SERVER_TLS" = "false" ]
 then
-  if [ -n "$ZOWE_ZSS_SERVER_PORT" ]
+  # HTTP
+  if [ -z "$ZWED_agent_http_port" ]
   then
-    export ZWED_agent_https_port=$ZOWE_ZSS_SERVER_PORT
+    if [ -n "$ZOWE_ZSS_SERVER_PORT" ]
+    then
+      export ZWED_agent_http_port=$ZOWE_ZSS_SERVER_PORT
+    fi
+  fi
+else
+  # HTTPS
+  if [ -z "$ZWED_agent_https_port" ]
+  then
+    if [ -n "$ZOWE_ZSS_SERVER_PORT" ]
+    then
+      export ZWED_agent_https_port=$ZOWE_ZSS_SERVER_PORT
+    fi
+  fi
+  if [ -z "$ZWED_agent_host" ]
+  then
+    export "ZWED_agent_host=${ZOWE_EXPLORER_HOST}"
   fi
 fi
 if [ -z "$ZWED_privilegedServerName" ]

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -169,11 +169,11 @@ then
 fi
 
 # zss
-if [ -z "$ZWED_agent_http_port" ]
+if [ -z "$ZWED_agent_https_port" ]
 then
   if [ -n "$ZOWE_ZSS_SERVER_PORT" ]
   then
-    export ZWED_agent_http_port=$ZOWE_ZSS_SERVER_PORT
+    export ZWED_agent_https_port=$ZOWE_ZSS_SERVER_PORT
   fi
 fi
 if [ -z "$ZWED_privilegedServerName" ]

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -118,9 +118,9 @@ if(process.env.overrideFileConfig !== "false"){
 }
 
 if (configJSON.agent) {
-  if (configJSON.agent.https) {
+  if (configJSON.agent.https && typeof configJSON.agent.https.port === 'number') {
     agentPort = configJSON.agent.https.port;
-  } else if (configJSON.agent.http) {
+  } else if (configJSON.agent.http && typeof configJSON.agent.http.port === 'number') {
     agentPort = configJSON.agent.http.port;
   } else {
     console.warn(`ZWED5006W - Invalid server configuration. Agent specified without http or https port`);

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -116,11 +116,14 @@ if(process.env.overrideFileConfig !== "false"){
 } else {
   console.log("ZWED5017I - Using config JSON, discarding CLI args");
 }
-
+const forceHttpForAgent = (process.env['ZOWE_ZSS_SERVER_TLS'] === 'false');
+let useHttpsForAgent = !forceHttpForAgent;
 if (configJSON.agent) {
-  if (configJSON.agent.https && typeof configJSON.agent.https.port === 'number') {
+  if (!forceHttpForAgent && configJSON.agent.https && typeof configJSON.agent.https.port === 'number') {
+    useHttpsForAgent = true;
     agentPort = configJSON.agent.https.port;
   } else if (configJSON.agent.http && typeof configJSON.agent.http.port === 'number') {
+    useHttpsForAgent = false;
     agentPort = configJSON.agent.http.port;
   } else {
     console.warn(`ZWED5006W - Invalid server configuration. Agent specified without http or https port`);
@@ -177,8 +180,15 @@ if(process.env.overrideFileConfig !== "false"){
 if (agentHost && agentPort) {
   configJSON.agent = configJSON.agent || {};
   configJSON.agent.host = agentHost;
-  configJSON.agent.http = configJSON.agent.http || {};
-  configJSON.agent.http.port = agentPort;
+  if (useHttpsForAgent) {
+    configJSON.agent.https = configJSON.agent.https || {};
+    configJSON.agent.https.port = agentPort;
+    configJSON.agent.http = {};
+  } else {
+    configJSON.agent.http = configJSON.agent.http || {};
+    configJSON.agent.http.port = agentPort;
+    configJSON.agent.https = {};
+  }
 }
 const startUpConfig = {
   proxiedHost: agentHost,


### PR DESCRIPTION
## Use https for zss agent by default

Related PRs:
- TLS Support zowe/zss#226
- Cipher suite definitions zowe/zowe-common-c#199
- TLS support for ZSS agent zowe/zlux-server-framework#271

Linked issue: zowe/zlux#632