### PR TITLE
Set hostname based on zowe environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v1.21.0
+
+- Bugfix: Set the hostname used for eureka to match the value of ZWE_EXTERNAL_HOSTS if exists, or otherwise ZOWE_EXLORER_HOST, for the purpose of avoiding certificate verification issues between app-server and APIML under certain circumstances
+
 ## v1.20.0
 
 - Added a manifest file, a validate script, and refactored configure, start, and app-server scripts to better conform to zowe lifecycle management standards

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -55,6 +55,16 @@ then
     export ZWED_node_mediationLayer_enabled="false"
 fi
 
+# eureka hostname handling
+if [ -z "$ZWED_node_hostname" ]; then
+  if [ -n "$ZWE_EXTERNAL_HOSTS" ]; then
+    #just the first value in the csv
+    export ZWED_node_hostname=$(echo "${ZWE_EXTERNAL_HOSTS}" | head -n1 | cut -d " " -f1 | sed "s/,/ /g")
+  elif [ -n "$ZOWE_EXPLORER_HOST" ]; then
+    export ZWED_node_hostname=$ZOWE_EXPLORER_HOST
+  fi
+fi
+
 if [ -n "$ZOWE_LOOPBACK_ADDRESS" ]
 then
   if [ -n "$ZOWE_IP_ADDRESS" ]


### PR DESCRIPTION
Certain parts of our server get the hostname by querying the system in a way that may result in an incorrect or short hostname, rather than a correct and fully qualified one.
But, the correct value is already recorded in the zowe environment, so we should use it when possible.
Resolves https://github.com/zowe/zlux/issues/566