### PR TITLE
adjust app server start script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ bin/mvdserver
 *.o
 /externals
 log/
+node_modules
 
 # emacs
 *~

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -160,7 +160,7 @@ fi
 #Determined log file.  Run node appropriately.
 cd ../lib
 
-export ZOWE_LIB_DIR=$(cd `dirname $0` && pwd)
+export ZOWE_LIB_DIR=$(pwd)
 
 export "_CEE_RUNOPTS=XPLINK(ON),HEAPPOOLS(ON)"
 

--- a/bin/install-app.sh
+++ b/bin/install-app.sh
@@ -154,10 +154,10 @@ echo "utils_path=${utils_path}\napp_path=${app_path}"
 if [ -d "$plugin_dir" ]
 then
   echo "plugin_dir=${plugin_dir}"
-{ __UNTAGGED_READ_MODE=V6 ${NODE_BIN} ${utils_path}/install-app.js -i "$app_path" -p "$plugin_dir" $@ 2>&1 ; echo "Ended with rc=$?" ; } | tee $PLUGIN_LOG_FILE
+{ __UNTAGGED_READ_MODE=V6 ${NODE_BIN} ${utils_path}/install-app.js -i "$app_path" -p "$plugin_dir" $@ 2>&1 ; echo "Ended with rc=$?" ; } | tee -a $PLUGIN_LOG_FILE
 else
   echo "json_path=${json_path}"
-{ __UNTAGGED_READ_MODE=V6 ${NODE_BIN} ${utils_path}/install-app.js -i "$app_path" -c "$json_path" $@ 2>&1 ; echo "Ended with rc=$?" ; } | tee $PLUGIN_LOG_FILE
+{ __UNTAGGED_READ_MODE=V6 ${NODE_BIN} ${utils_path}/install-app.js -i "$app_path" -c "$json_path" $@ 2>&1 ; echo "Ended with rc=$?" ; } | tee -a $PLUGIN_LOG_FILE
 fi
 
 fi


### PR DESCRIPTION
Signed-off-by: Nakul Manchanda <nakul.manchanda@ibm.com>

- Modified app-server.sh -> it was switching to different folder than lib, as line before `cd ../lib`, we already at lib
changed assignment to variable `ZOWE_LIB_DIR`, removed switching folder again to `cd $0`

- There is one more change -> now we append logs whenever we run `install-app.sh`


All changes have been tested with custom zowe build