### PR TITLE
Docker zss-thru-apiml workaround

### DIFF
--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -53,7 +53,10 @@ fi
 if [ -z "$ZWED_node_mediationLayer_enabled" ]; then
   export ZWED_node_mediationLayer_enabled="false"
 elif [ -z "$ZWED_agent_mediationLayer_enabled" ]; then
-  export ZWED_agent_mediationLayer_enabled="true";
+  if [[ "${OSNAME}" == "OS/390" ]]; then
+    export ZWED_agent_mediationLayer_enabled="true";
+  fi
+  # else: docker... no static def file for zss means no zss unless the end user added one manually, so lets not set true here. If end user sets up a static file, they can set this true manually as well.
 fi
 
 # Check if Caching Service is enabled


### PR DESCRIPTION
workaround for docker trying to connect to zss thru apiml when its not found there

Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->
In our codebase, we assume zss can be found on the apiml if we can construct a url to it and find the apiml to be running.
However, zss is only available there when a static def file is set up, which only happens when zss and apiml are in the same place. In docker, that's not true and therefore we can't connect to zss in this way. For now, this is a temporarily workaround to disable this feature for docker.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Change in a documentation
- [ ] Refactor the code 
- [ ] Chore, repository cleanup, updates the dependencies.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## PR Checklist
Please delete options that are not relevant.
- [ ] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [ ] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->
Run the latest docker image. You'll see the error
`ZWED0151W - unhandledRejection Error: Call timeout when fetching agent status from APIML`
With this PR, that should go away due to not trying to reach apiml for zss.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
This should be fixed long-term in another way, by actually making zss accessible through apiml in docker. I guess this could be done by having the docker scripting make the static def file on behalf of zss.
