### PR TITLE
Add missing env var init

### DIFF
--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -209,3 +209,8 @@ then
     export ZWED_privilegedServerName=$ZOWE_ZSS_XMEM_SERVER_NAME
   fi 
 fi
+
+# cert verification
+if [ -z "$ZWED_node_allowInvalidTLSProxy" -a -n "$VERIFY_CERTIFICATES" ]; then
+  export ZWED_node_allowInvalidTLSProxy="${VERIFY_CERTIFICATES}"
+fi

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -7,6 +7,8 @@
 #
 # Copyright Contributors to the Zowe Project.
 
+OSNAME=$(uname)
+
 # For backwards compatible behavior, only set the instance ID if it is non-default
 if [ -n "$ZOWE_INSTANCE" ]
 then

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -212,5 +212,7 @@ fi
 
 # cert verification
 if [ -z "$ZWED_node_allowInvalidTLSProxy" -a -n "$VERIFY_CERTIFICATES" ]; then
-  export ZWED_node_allowInvalidTLSProxy="${VERIFY_CERTIFICATES}"
+  if [ "$VERIFY_CERTIFICATES" = "false" ]; then
+    export ZWED_node_allowInvalidTLSProxy="true"
+  fi
 fi


### PR DESCRIPTION
The OSNAME used in PR #162 did not have an initial value, so the check would have been false in all cases, leading to what we wanted on docker but not on z/os.