### PR TITLE
Add static reg file to conditionally give to gateway for connecting zss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v1.22.0
+
+- Enhancement: Allow zss to be accessed through gateway when in a container by having app-server notify gateway about zss existence.
+
 ## v1.21.0
 
 - Bugfix: Set the hostname used for eureka to match the value of ZWE_EXTERNAL_HOSTS if exists, or otherwise ZOWE_EXLORER_HOST, for the purpose of avoiding certificate verification issues between app-server and APIML under certain circumstances

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -17,3 +17,14 @@ cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/bin
 . ./internal-node-init.sh
 cd ${ROOT_DIR}/components/app-server/share/zlux-app-server/lib
 __UNTAGGED_READ_MODE=V6 $NODE_BIN initInstance.js
+OSNAME=$(uname)
+
+# conditionally set up static reg file for zss if app-server is remote to zss
+# if apiml isnt in this environment, this is harmless but does nothing, otherwise zss is attached
+if [ "${OSNAME}" != "OS/390" ]; then
+  if [ "$ZWED_agent_mediationLayer_enabled" = "true" ]; then
+    cp ${ROOT_DIR}/components/app-server/share/zlux-app-server/zss_static_registration.yaml.template ${INSTANCE_DIR}/workspace/api-mediation/api-defs/zss_static_registration_template.yml
+  elif [ -e "${INSTANCE_DIR}/workspace/api-mediation/api-defs/container-zss-static-reg.yaml.template.yml" ]; then
+    rm ${INSTANCE_DIR}/workspace/api-mediation/api-defs/zss_static_registration_template.yml
+  fi
+fi

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -55,10 +55,7 @@ fi
 if [ -z "$ZWED_node_mediationLayer_enabled" ]; then
   export ZWED_node_mediationLayer_enabled="false"
 elif [ -z "$ZWED_agent_mediationLayer_enabled" ]; then
-  if [[ "${OSNAME}" == "OS/390" ]]; then
-    export ZWED_agent_mediationLayer_enabled="true";
-  fi
-  # else: docker... no static def file for zss means no zss unless the end user added one manually, so lets not set true here. If end user sets up a static file, they can set this true manually as well.
+  export ZWED_agent_mediationLayer_enabled="true";
 fi
 
 # Check if Caching Service is enabled

--- a/container-zss-static-reg.yaml.template
+++ b/container-zss-static-reg.yaml.template
@@ -1,0 +1,20 @@
+services:
+  - serviceId: zss
+    title: Zowe System Services (ZSS)
+    description: 'Zowe System Services is an HTTPS and Websocket server that makes it easy to have secure, powerful web APIs backed by low-level z/OS constructs. It contains services for essential z/OS abilities such as working with files, datasets, and ESMs, but is also extensible by REST and Websocket "Dataservices" which are optionally present in App Framework "Plugins".'
+    catalogUiTileId: zss
+    instanceBaseUrls:
+      - https://${ZWED_agent_host}:${ZOWE_ZSS_SERVER_PORT}/
+    homePageRelativeUrl:
+    routedServices:
+      - gatewayUrl: api/v1
+        serviceRelativeUrl: 
+    apiInfo:
+      - apiId: org.zowe.zss
+        gatewayUrl: api/v1
+        # swaggerUrl: TODO
+        # documentationUrl: TODO
+catalogUiTiles:
+  zss:
+    title: Zowe System Services (ZSS)
+    description:  Zowe System Services is an HTTPS and Websocket server that makes it easy to have secure, powerful web APIs backed by low-level z/OS constructs.


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

In 1.21.0, zss is accessible thru apiml and the desktop respects this by making calls to gateway:port/api/v1/zss in the browser rather than gateway:port/ui/v1/zlux or app-server:port/
However, that only works for zos. In docker, because zss is not on the same system, no static registration file exists and therefore zss is not available on the gateway, so this option is not possible on docker today. This PR fixes it by making a static reg file available to the gateway conditionally.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->
Without any customization needed, the desktop within docker should be using /api/v1/zss routes when making calls to zss in apps such as the editor. This is compared to v1.21.0, where calls would be made to /ui/v1/zlux instead.

Note: you must test this via the apiml address for the desktop, not via the desktop directly, which should not change before and after this PR.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
