### PR TITLE
relativeTo cant be used in build pipeline

### DIFF
--- a/defaults/plugins/org.zowe.zlux.agent.json
+++ b/defaults/plugins/org.zowe.zlux.agent.json
@@ -1,5 +1,0 @@
-{
-  "identifier": "org.zowe.zlux.agent",
-  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/zlux-agent",
-  "relativeTo": "$ROOT_DIR"
-}

--- a/defaults/plugins/org.zowe.zlux.json
+++ b/defaults/plugins/org.zowe.zlux.json
@@ -1,5 +1,0 @@
-{
-  "identifier": "org.zowe.zlux",
-  "pluginLocation": "components/app-server/share/zlux-server-framework/plugins/zlux-server",
-  "relativeTo": "$ROOT_DIR"
-}


### PR DESCRIPTION
Small fix to temporarily revert the addition of 2 plugins as they break build because build cannot handle the env var resolution.