### PR TITLE
Add user-info to the list of agent services

### DIFF
--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -250,6 +250,10 @@ if (startUpConfig.proxiedHost && startUpConfig.proxiedPort) {
         method: '*',
         url: '/password',
         requiresAuth: false
+      },
+      {
+        method: '*',
+        url: '/user-info'
       }
     ];
 }


### PR DESCRIPTION
## Proposed changes
This PR add `/user-info` endpoint to the list of proxied agent services.

This PR depends upon the following PRs: https://github.com/zowe/zss/pull/336

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
