### PR TITLE
Update install-app to work better in container

### DIFF
--- a/bin/install-app.sh
+++ b/bin/install-app.sh
@@ -40,8 +40,10 @@ then
 
   # containers only
   if [ ! -f "${COMPONENT_HOME}/manifest.yaml" ]; then
-    if [ -f "/component/manifest.yaml" ]; then
+    # these files may exist in other containers where this script is run from, rather than just zlux
+    if [ -f "/component/manifest.yaml" -o -f "/component/manifest.json" -o -f "/component/manifest.yml" ]; then
       COMPONENT_HOME=/component
+      ZLUX_CONTAINER_MODE=1  
       INSTALL_NO_NODE=1  
     fi
   fi
@@ -77,10 +79,10 @@ shift
 
 if [ -z "$plugin_dir" ]
 then
-  if [ "$COMPONENT_HOME" = "/component" ]
+  if [ "$ZLUX_CONTAINER_MODE" = "1" ]
   then
     #container, plugins folder in fixed location
-    fallback_inst=${INSTANCE_DIR}    
+    fallback_inst=${INSTANCE_DIR}
   elif [ -e "${INSTANCE_DIR}/workspace/app-server/serverConfig/server.json" ]
   then
     json_path=${INSTANCE_DIR}/workspace/app-server/serverConfig/server.json
@@ -118,6 +120,12 @@ installNojs() {
   if [ -n "${id}" ]
   then
     echo "Found plugin=${id}"
+
+    if [ "$ZLUX_CONTAINER_MODE" = "1" ]
+    then
+      # install script expected to copy the plugin into this location. could be done manually too.
+      app_path=$INSTANCE_DIR/workspace/app-server/pluginDirs/${id}
+    fi
 
 cat <<EOF >${fallback_inst}/workspace/app-server/plugins/${id}.json
 {

--- a/bin/install-app.sh
+++ b/bin/install-app.sh
@@ -42,15 +42,18 @@ then
   if [ ! -f "${COMPONENT_HOME}/manifest.yaml" ]; then
     if [ -f "/component/manifest.yaml" ]; then
       COMPONENT_HOME=/component
+      INSTALL_NO_NODE=1  
     fi
   fi
-  
-  zlux_path="$COMPONENT_HOME/share"
-  setVars
-  if [ ! -e "${INSTANCE_DIR}/workspace/app-server/serverConfig/server.json" ]
-  then
-    cd ${zlux_path}/zlux-app-server/lib
-    __UNTAGGED_READ_MODE=V6 $NODE_BIN initInstance.js
+
+  if [ -z "$INSTALL_NO_NODE" ]; then
+    zlux_path="$COMPONENT_HOME/share"
+    setVars
+    if [ ! -e "${INSTANCE_DIR}/workspace/app-server/serverConfig/server.json" ]
+    then
+      cd ${zlux_path}/zlux-app-server/lib
+      __UNTAGGED_READ_MODE=V6 $NODE_BIN initInstance.js
+    fi
   fi
 elif [ -d "${dir}/../../zlux-server-framework" ]
 then
@@ -74,7 +77,11 @@ shift
 
 if [ -z "$plugin_dir" ]
 then
-  if [ -e "${INSTANCE_DIR}/workspace/app-server/serverConfig/server.json" ]
+  if [ "$COMPONENT_HOME" = "/component" ]
+  then
+    #container, plugins folder in fixed location
+    fallback_inst=${INSTANCE_DIR}    
+  elif [ -e "${INSTANCE_DIR}/workspace/app-server/serverConfig/server.json" ]
   then
     json_path=${INSTANCE_DIR}/workspace/app-server/serverConfig/server.json
     fallback_inst=${INSTANCE_DIR}  
@@ -92,8 +99,6 @@ This configuration should be migrated for use with future versions. See document
   fi
 fi
 
-
-cd $zlux_path/zlux-app-server/bin
 
 installNojs() {
  echo "NodeJS not found or not requested, attempting fallback plugin install behavior"
@@ -131,6 +136,8 @@ if [ -n "$INSTALL_NO_NODE" ]
 then
  installNojs
 else  
+  cd $zlux_path/zlux-app-server/bin
+
   echo "Testing if node exists"
   type ${NODE_BIN}
   rc=$?


### PR DESCRIPTION
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>

<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This is meant to allow install-app to work in the containers other than the app-server's own container.
In this mode, install-app.sh will live in the instance, but zlux-core will not be there.
So, we activate "nojs" mode, which does not need zlux-core. The install skips validation but does write the install file.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [ ] Relevant update to CHANGELOG.md
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
<!-- Describe how this code should be tested. I've you've added an automated or unit test, then describe how to run it. Otherwise, describe how you have tested it and how others should test it. -->

Do existing regression tests about
- Can I install an app in a dev env
- Can I install an app on z/os (before&after initial run)

Now test new case:
Before PR: explorers dont show up in container desktop
After PR: explorers do show up.

## Further comments
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, or if there are follow-up tasks and TODOs etc... -->
