### PR TITLE
Bugfix for when running in a dev environment without an agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
-## v1.26.0
+## v1.27.0
 
 - Bugfix: Fix development environment case in which app-server would crash without agent config being fully defined.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v1.26.0
+
+- Bugfix: Fix development environment case in which app-server would crash without agent config being fully defined.
+
 ## v1.25.0
 
 - Enhancement: Changed how app-server scripts locate app-server directories so that they work in container mode, where the folder layout is different. This unifies container and non-container location behavior.

--- a/README.md
+++ b/README.md
@@ -310,7 +310,11 @@ On a release install (not covered here, but described on docs.zowe.org), ZSS is 
 
 On a dev install of ZSS, instead of instance.env, server.json is used just like the dev install of the app-server. In fact if App Server and ZSS are on the same system, then this can be the same file. Otherwise, you must edit the server.json file where ZSS is and keep it in sync with the App Server one with regards to the **agent** settings. In a dev install, it is recommended to use a GSKIT compatible keyring or p12 file for using ZSS over HTTPS, or HTTPS via ATTLS, but HTTP is also possible. In that case, you simply configure `agent.http.port` instead of `agent.https.port`, and `agent.http.ipAddresses` instead of `agent.https.ipAddresses`. So, use server.json to set the port and IPs you need to make ZSS visible to the system where app-server runs.
 
-**Note: It is highly recommended to turn on HTTPS for ZSS such as by following [configuring AT-TLS](https://zowe.github.io/docs-site/latest/user-guide/mvd-configuration.html#configuring-zss-for-https) or using GSKIT when using ZSS externally, as the session security is essential for all but trivial development environments**
+**Note: It is highly recommended to have HTTPS for ZSS. This is the default on a release install, but it is also possible to use AT-TLS to do this such as by following [configuring AT-TLS](https://zowe.github.io/docs-site/latest/user-guide/mvd-configuration.html#configuring-zss-for-https). It is most important when using ZSS externally, as the session security is essential for all but trivial development environments**
+
+#### Agent swagger installation
+If you intend to use the API Catalog as well, you will want to [install the plugin](https://github.com/zowe/zlux/wiki/Installing-Plugins) "zlux-agent", found in `zlux-server-framework/plugins/zlux-agent`.
+This allows the app-server to serve agent swagger definitions, which are then visible in the API catalog.
 
 
 ### Starting App Server when using ZSS

--- a/bin/convert-env.sh
+++ b/bin/convert-env.sh
@@ -176,21 +176,21 @@ fi
 #SSO
 if [ -z "$ZWED_agent_jwt_fallback" ]
 then
-  if [ -n $SSO_FALLBACK_TO_NATIVE_AUTH ]
+  if [ -n "$SSO_FALLBACK_TO_NATIVE_AUTH" ]
   then
     export ZWED_agent_jwt_fallback=$SSO_FALLBACK_TO_NATIVE_AUTH
   fi
 fi
 if [ -z "$ZWED_agent_jwt_token_name" ]
 then
-  if [ -n $PKCS11_TOKEN_NAME ]
+  if [ -n "$PKCS11_TOKEN_NAME" ]
   then
     export ZWED_agent_jwt_token_name=$PKCS11_TOKEN_NAME
   fi
 fi
 if [ -z "$ZWED_agent_jwt_token_label" ]
 then
-  if [ -n $PKCS11_TOKEN_LABEL ]
+  if [ -n "$PKCS11_TOKEN_LABEL" ]
   then
     export ZWED_agent_jwt_token_label=$PKCS11_TOKEN_LABEL
   fi

--- a/defaults/plugins/org.zowe.zlux.agent.json
+++ b/defaults/plugins/org.zowe.zlux.agent.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "org.zowe.zlux.agent",
-  "pluginLocation": "../../zlux-server-framework/plugins/zlux-agent"
-}


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR addresses the fact the dev readme ends up giving you an unusable environment due to internal logic expecting agent config to be entirely present or entirely missing, and we had some present but useless object by default in which all the values were 0, and this confused the server.

Similarly, I noticed that when agent is not present, the swagger plugin for sending agent docs also should not be present as it does not have any logic to detect the difference, so it should just not be included by default in a dev environment.


This PR addresses Issue: https://github.com/zowe/zlux/issues/758

This PR depends upon the following PRs: https://github.com/zowe/zlux-server-framework/pull/344

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
