### PR TITLE
Fix jobname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v1.28.0
+
+- Bugfix: App-server had a jobname prefix regression for several releases when it recieved an incorrect value for ZOWE_PREFIX when LAUNCH_COMPONENT_GROUPS included GATEWAY
+
 ## v1.27.0
 
 - Bugfix: Fix development environment case in which app-server would crash without agent config being fully defined.

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -188,5 +188,15 @@ then
 else
   ZLUX_SERVER_FILE=zluxServer.js
 fi
+
+# Weird bug in recent releases has app-server not having the same jobname prefix as other services.
+# This only happens when LAUNCH_COMPONENT_GROUPS includes GATEWAY.
+# Possibly due to hacks elsewhere that we weren't notified of https://github.com/zowe/zowe-install-packaging/commit/0ccb77afca8f6dd8e2782c25490283739ab2791c
+if [ -n "${ZOWE_INSTANCE}" ]; then
+  if [[ "${ZOWE_PREFIX}" != *"${ZOWE_INSTANCE}" ]]; then
+    export ZOWE_PREFIX=${ZOWE_PREFIX}${ZOWE_INSTANCE}
+  fi
+fi
+
 { __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZOWE_PREFIX}DS1 ${NODE_BIN} --harmony ${ZOWE_LIB_DIR}/${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE
 


### PR DESCRIPTION
## Proposed changes

Some users have reported that the jobname of some servers have changed. This appears to effect app-server when the gateway group is running, but regardless a solution could be to force the zowe prefix to include the zowe instance. While modifying a user-configured variable to include another user-configured variable this seems wrong, it's what the rest of the code has been doing for a very long time, so I'm repeating it to be in alignment.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

Start Zowe up via STC to see if the jobname of app-server is for example ZWE1DS1 versus ZWEDS1.