### PR TITLE
Update convert-env.sh to fix keyring root ca

### DIFF
--- a/bin/utils/convert-env.sh
+++ b/bin/utils/convert-env.sh
@@ -189,7 +189,7 @@ then
   then
     if [ -z "$LOCAL_CA" ]
     then
-      LOCAL_CA=localca
+      LOCAL_CA=$ZWE_zowe_certificate_pem_certificateAuthorities
     fi
     #, at end turns it into an array
     if [ -n "$EXTERNAL_ROOT_CA" ]

--- a/bin/utils/convert-env.sh
+++ b/bin/utils/convert-env.sh
@@ -187,16 +187,12 @@ if [ -z "$ZWED_node_https_certificateAuthorities" ]
 then
   if [ "$KEYSTORE_TYPE" = "JCERACFKS" ]
   then
-    if [ -z "$LOCAL_CA" ]
-    then
-      LOCAL_CA=$ZWE_zowe_certificate_pem_certificateAuthorities
-    fi
     #, at end turns it into an array
     if [ -n "$EXTERNAL_ROOT_CA" ]
     then
-      export ZWED_node_https_certificateAuthorities="${TRUSTSTORE}&${LOCAL_CA}","${TRUSTSTORE}&${EXTERNAL_ROOT_CA}"
+      export ZWED_node_https_certificateAuthorities="${ZWE_zowe_certificate_pem_certificateAuthorities}","${TRUSTSTORE}&${EXTERNAL_ROOT_CA}"
     else
-      export ZWED_node_https_certificateAuthorities="${TRUSTSTORE}&${LOCAL_CA}",
+      export ZWED_node_https_certificateAuthorities="${ZWE_zowe_certificate_pem_certificateAuthorities}",
     fi
   elif [ -n "$KEYSTORE_CERTIFICATE_AUTHORITY" ]
   then


### PR DESCRIPTION
## Proposed changes
It appears in keyring scenario of v2, the default behavior of the app-server attempt to find the root ca is never correct, where it just uses 'localca'. Instead, the value of the CA of the pem section seems more correct though I have doubts about the format of the pem section, it shouldn't change without it being a breaking change so we should be able to depend upon its value.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] New and existing unit tests pass locally with my changes
- [ ] Relevant update to CHANGELOG.md
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing
Not yet tested, needs to be revisited soon.