### PR TITLE
Fix that filename and fileName are both valid to load a router in the app server

### DIFF
--- a/schemas/plugindefinition-schema.json
+++ b/schemas/plugindefinition-schema.json
@@ -382,7 +382,7 @@
     "routerService": {
       "allOf": [ { "$ref": "#/$defs/service" } ],
       "description": "An ExpressJS router service hosted from the app-server",
-      "required": ["type", "version", "name", "fileName", "routerFactory"],
+      "required": ["type", "version", "name", "routerFactory"],
       "unevaluatedProperties": false,
       "properties": {
         "type": {
@@ -398,9 +398,13 @@
           "default": true,
           "deprecated": true
         },
-        "fileName": {
+        "filename": {
           "type": "string",
           "description": "A javascript file located within the plugin's 'lib' folder which contains the router factory. The router is for a REST or Websocket API that the app-server will include."
+        },
+        "fileName": {
+          "type": "string",
+          "description": "Alias of 'filename'."
         },
         "routerFactory": {
           "type": "string",


### PR DESCRIPTION
## Proposed changes
I found I could not install apps which used "filename" instead of "fileName", but in the server framework code I found that both are valid. It's not that we are case insensitive, it's just that both are checked.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
