### PR TITLE
Make schema multi-file

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,7 +13,9 @@ keywords:
   - appfw
 license: EPL-2.0
 schemas:
-  configs: schemas/zowe-schema.json
+  configs: 
+  - schemas/zowe-schema.json
+  - schemas/app-server-config.json
 repository:
   type: git
   url: https://github.com/zowe/zlux-app-server.git

--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -4,7 +4,6 @@
   "title": "app-server configuration",
   "description": "Configuration properties for the app-server, as specified within a configuration file such as zowe.yaml",
   "type": "object",
-  "required": [ "productDir", "siteDir", "instanceDir", "groupsDir", "usersDir", "pluginsDir", "dataserviceAuthentication", "node" ],
   "additionalProperties": true,
   "properties": {
     "node": {


### PR DESCRIPTION
We have multiple schema files for app-server config and so we have to declare it as such in order to be compatible with component validation as seen in https://github.com/zowe/zowe-install-packaging/pull/3006