### PR TITLE
Bugfix: cross-schema ref not configmgr-compatible

### DIFF
--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -17,8 +17,8 @@
           "properties": {
             "port": {
               "oneOf": [
-                { "$ref": "/schemas/v2/server-common/#zoweTcpPort" },
-                { "$ref": "/schemas/v2/server-common/#zoweReservedTcpPort" }, 
+                { "$ref": "/schemas/v2/server-common#zoweTcpPort" },
+                { "$ref": "/schemas/v2/server-common#zoweReservedTcpPort" }, 
               ],
               "default": 7556
             },
@@ -76,8 +76,8 @@
           "properties": {
             "port": {
               "oneOf": [
-                { "$ref": "/schemas/v2/server-common/#zoweTcpPort" },
-                { "$ref": "/schemas/v2/server-common/#zoweReservedTcpPort" }, 
+                { "$ref": "/schemas/v2/server-common#zoweTcpPort" },
+                { "$ref": "/schemas/v2/server-common#zoweReservedTcpPort" }, 
               ]
             },
             "ipAddresses": {
@@ -110,15 +110,15 @@
                 },
                 "gatewayPort": {
                   "oneOf": [
-                    { "$ref": "/schemas/v2/server-common/#zoweTcpPort" },
-                    { "$ref": "/schemas/v2/server-common/#zoweReservedTcpPort" }, 
+                    { "$ref": "/schemas/v2/server-common#zoweTcpPort" },
+                    { "$ref": "/schemas/v2/server-common#zoweReservedTcpPort" }, 
                   ],
                   "description": "The port where the Zowe Gateway service is running"
                 },
                 "port": {
                   "oneOf": [
-                    { "$ref": "/schemas/v2/server-common/#zoweTcpPort" },
-                    { "$ref": "/schemas/v2/server-common/#zoweReservedTcpPort" }, 
+                    { "$ref": "/schemas/v2/server-common#zoweTcpPort" },
+                    { "$ref": "/schemas/v2/server-common#zoweReservedTcpPort" }, 
                   ],
                   "description": "The port where the Zowe Discovery service is running"
                 },
@@ -252,8 +252,8 @@
           "properties": {
             "port": {
               "oneOf": [
-                { "$ref": "/schemas/v2/server-common/#zoweTcpPort" },
-                { "$ref": "/schemas/v2/server-common/#zoweReservedTcpPort" }, 
+                { "$ref": "/schemas/v2/server-common#zoweTcpPort" },
+                { "$ref": "/schemas/v2/server-common#zoweReservedTcpPort" }, 
               ],
               "default": 7557
             },
@@ -270,8 +270,8 @@
           "properties": {
             "port": {
               "oneOf": [
-                { "$ref": "/schemas/v2/server-common/#zoweTcpPort" },
-                { "$ref": "/schemas/v2/server-common/#zoweReservedTcpPort" }, 
+                { "$ref": "/schemas/v2/server-common#zoweTcpPort" },
+                { "$ref": "/schemas/v2/server-common#zoweReservedTcpPort" }, 
               ]
             },
             "attls": {
@@ -365,7 +365,7 @@
                 "plugins": {
                   "type": "array",
                   "items": {
-                    "$ref": "/schemas/v2/server-common/#zoweReverseDomainNotation"
+                    "$ref": "/schemas/v2/server-common#zoweReverseDomainNotation"
                   },
                   "uniqueItems": true
                 }
@@ -438,8 +438,8 @@
               "type": "array",
               "items": {
                 "anyOf": [
-                  { "$ref": "/schemas/v2/server-common/#zoweTcpPort" },
-                  { "$ref": "/schemas/v2/server-common/#zoweReservedTcpPort" }, 
+                  { "$ref": "/schemas/v2/server-common#zoweTcpPort" },
+                  { "$ref": "/schemas/v2/server-common#zoweReservedTcpPort" }, 
                 ],
                 "minItems": 2,
                 "maxItems": 2
@@ -449,8 +449,8 @@
               "type": "array",
               "items": {
                 "anyOf": [
-                  { "$ref": "/schemas/v2/server-common/#zoweTcpPort" },
-                  { "$ref": "/schemas/v2/server-common/#zoweReservedTcpPort" }, 
+                  { "$ref": "/schemas/v2/server-common#zoweTcpPort" },
+                  { "$ref": "/schemas/v2/server-common#zoweReservedTcpPort" }, 
                 ],
                 "uniqueItems": true
               }
@@ -485,7 +485,7 @@
                       "plugins": {
                         "type": "array",
                         "items": {
-                          "$ref": "/schemas/v2/server-common/#zoweReverseDomainNotation"
+                          "$ref": "/schemas/v2/server-common#zoweReverseDomainNotation"
                         }
                       }
                     }


### PR DESCRIPTION
Configmgr resolves cross-schema references that are `some/id#some-label` but it cannot handle ids that end with a slash, rather it must be omitted. We updated most repos to respect this but zlux-app-server needed it too. So, I just removed trailing slashes for /schemas/v2/server-common