### PR TITLE
Force ipv4 dns lookup for app-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v2.7.0
+
+- Bugfix: Explicitly prefer ipv4 dns results to be compatible with node 18 since it switched to prefer ipv6 without configuration. This behavior can be cusomized via components.app-server.dns.lookupOrder='ipv4' or 'ipv6'. It defaults to 'ipv4'.
+
 ## v2.4.0
 
 - Bugfix: Plugin register/deregister would not consider app2app actions and recgonizers. Now, they are added on registration and removed on deregistration.

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -91,10 +91,29 @@ else
   ZLUX_SERVER_FILE=zluxServer.js
 fi
 
-if [ -z "$ZLUX_NO_LOGFILE" ]; then
-    __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZOWE_PREFIX}DS ${NODE_BIN} --harmony ${ZOWE_LIB_DIR}/${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 | tee $ZWED_NODE_LOG_FILE
+ZLUX_DNS_ORDER=
+if [ "$ZWE_components_app_server_dns_lookupOrder" = "ipv6" ]; then
+  ZLUX_DNS_ORDER="--dns-result-order=verbatim"
 else
-    __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZOWE_PREFIX}DS ${NODE_BIN} --harmony ${ZOWE_LIB_DIR}/${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@"
+  ZLUX_DNS_ORDER="--dns-result-order=ipv4first"
+fi
+
+if [ -z "$ZLUX_NO_LOGFILE" ]; then
+    __UNTAGGED_READ_MODE=V6 \
+    _BPX_JOBNAME=${ZOWE_PREFIX}DS \
+    ${NODE_BIN} \
+    --harmony \
+    ${ZLUX_DNS_ORDER} \
+    ${ZOWE_LIB_DIR}/${ZLUX_SERVER_FILE} \
+    --config="${CONFIG_FILE}" "$@" 2>&1 | tee $ZWED_NODE_LOG_FILE
+else
+    __UNTAGGED_READ_MODE=V6 \
+    _BPX_JOBNAME=${ZOWE_PREFIX}DS \
+    ${NODE_BIN} \
+    --harmony \
+    ${ZLUX_DNS_ORDER} \
+    ${ZOWE_LIB_DIR}/${ZLUX_SERVER_FILE} \
+    --config="${CONFIG_FILE}" "$@"
     echo "Ended with rc=$?"
 fi
 

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -91,11 +91,9 @@ else
   ZLUX_SERVER_FILE=zluxServer.js
 fi
 
-ZLUX_DNS_ORDER=
+ZLUX_DNS_ORDER="--dns-result-order=ipv4first"
 if [ "$ZWE_components_app_server_dns_lookupOrder" = "ipv6" ]; then
   ZLUX_DNS_ORDER="--dns-result-order=verbatim"
-else
-  ZLUX_DNS_ORDER="--dns-result-order=ipv4first"
 fi
 
 if [ -z "$ZLUX_NO_LOGFILE" ]; then

--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -556,6 +556,18 @@
     "privilegedServerName": {
       "type": "string",
       "description": "The nickname of the ZIS server to be used"
+    },
+    "dns": {
+      "type": "object",
+      "description": "Parameters used to customize DNS query behavior",
+      "properties": {
+        "lookupOrder": {
+          "type": "string",
+          "enum": [ "ipv4", "ipv6" ],
+          "default": "ipv4",
+          "description": "Used to specify to nodejs whether DNS lookups should return ipv4 or ipv6 IPs"
+        }
+      }
     }
   },
   "$defs": {


### PR DESCRIPTION
## Proposed changes
Node v17+ switches dns lookup to prefer ipv6 instead of ipv4. This would break the server if someone was using zowe with node 18 for example, since most of zowe listens on 0.0.0.0

I make the dns preference configurable here, so that in a future release, it could be more ipv6 compatible.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing
This behavior is NOT COMPATIBLE with node v12, but thats not supported anymore anyway.
You can test this behavior by using node directly,

node --dns-result-order=ipv4first
Welcome to Node.js v18.12.1.
Type ".help" for more information.
const dns = require('dns');
dns.lookup('myhost', (e, a, f)=> {console.log(a); console.log(f);});
GetAddrInfoReqWrap {
callback: [Function (anonymous)],
family: 0,
hostname: 'myhost',
oncomplete: [Function: onlookup]
}
192.168.1.23
4