### PR TITLE
 Force ipv4 dns lookup for app-server

### DIFF
--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -198,11 +198,9 @@ if [ -n "${ZOWE_INSTANCE}" ]; then
   fi
 fi
 
-ZLUX_DNS_ORDER=
+ZLUX_DNS_ORDER="--dns-result-order=ipv4first"
 if [ "$ZWE_components_app_server_dns_lookupOrder" = "ipv6" ]; then
   ZLUX_DNS_ORDER="--dns-result-order=verbatim"
-else
-  ZLUX_DNS_ORDER="--dns-result-order=ipv4first"
 fi
 
 { __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZOWE_PREFIX}DS1 ${NODE_BIN} --harmony ${ZLUX_DNS_ORDER} ${ZOWE_LIB_DIR}/${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE

--- a/bin/app-server.sh
+++ b/bin/app-server.sh
@@ -198,5 +198,12 @@ if [ -n "${ZOWE_INSTANCE}" ]; then
   fi
 fi
 
-{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZOWE_PREFIX}DS1 ${NODE_BIN} --harmony ${ZOWE_LIB_DIR}/${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE
+ZLUX_DNS_ORDER=
+if [ "$ZWE_components_app_server_dns_lookupOrder" = "ipv6" ]; then
+  ZLUX_DNS_ORDER="--dns-result-order=verbatim"
+else
+  ZLUX_DNS_ORDER="--dns-result-order=ipv4first"
+fi
+
+{ __UNTAGGED_READ_MODE=V6 _BPX_JOBNAME=${ZOWE_PREFIX}DS1 ${NODE_BIN} --harmony ${ZLUX_DNS_ORDER} ${ZOWE_LIB_DIR}/${ZLUX_SERVER_FILE} --config="${CONFIG_FILE}" "$@" 2>&1 ; echo "Ended with rc=$?" ; } | tee $ZLUX_NODE_LOG_FILE
 


### PR DESCRIPTION
Same as https://github.com/zowe/zlux-app-server/pull/249 but for v1
Note: This wont work for v12, which isnt supported anymore anyway.
Note: the env var name is a bit silly for v1 but all v1 env var names are a bit silly so this at least is consistent between v1 and v2.