### PR TITLE
Fix typo in plugins-init.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v2.9.0
+
+- Bugfix: Recognizers from multiple plugins could not be merged due to an error in the merge code execution at startup.
+
 ## v2.7.0
 
 - Bugfix: Explicitly prefer ipv4 dns results to be compatible with node 18 since it switched to prefer ipv6 without configuration. This behavior can be cusomized via components.app-server.dns.lookupOrder='ipv4' or 'ipv6'. It defaults to 'ipv4'.

--- a/bin/init/plugins-init.js
+++ b/bin/init/plugins-init.js
@@ -126,7 +126,7 @@ function copyRecognizers(appDir, appId, appVers) {
         configRecognizers = fs.fileExists(filepathConfig) ? JSON.parse(xplatform.loadFileUTF8(filepathConfig, xplatform.AUTO_DETECT)).recognizers : {};
         const configRecognizersKeys = Object.keys(configRecognizers);
         for (const configKey of configRecognizersKeys) { // Traverse config recognizers
-          for (const key of recognizerKeys) { // Traverse plugin recognizers
+          for (const key of recognizersKeys) { // Traverse plugin recognizers
             if (configRecognizers[configKey].key && recognizers[key].key && configRecognizers[configKey].key == recognizers[key].key) { // TODO: Need to implement real keys for Recognizers
               configRecognizers[configKey] = recognizers[key]; // Choose the recognizers originating from plugin
             }


### PR DESCRIPTION
This typo was causing an error at startup about "invalid json". The json was valid, but the typo threw an error.