### PR TITLE
Update defaults logic for multi-pem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v2.11.0
+
+- Bugfix: The server couldn't load more than one certificate authority specified within the zowe.certificate.pem.certificateAuthorities section under any condition. Now, it is supported regardless of if the section is an array or a comma-separated string. (#266)
+
 ## v2.10.0
 
 - Enhancement: Migrated app-server configuration options into a "defaults.yaml" file which adheres to the schema of the Zowe config. This allows users to see the default behaviors more clearly, and can serve as an example by which users can customize their Zowe config to override such defaults. (#247)

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -54,7 +54,7 @@ components:
                                           if (Array.isArray(zowe.certificate.pem.certificateAuthorities)) {
                                             return zowe.certificate.pem.certificateAuthorities;
                                           } else {
-                                            return zowe.certificate.pem.certificateAuthorities.split(',');
+                                            return zowe.certificate.pem.certificateAuthorities.split(",");
                                           }
                                         } else { return ["../defaults/serverConfig/apiml-localca.cer"]; } };
                                   a() }}'

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -51,7 +51,11 @@ components:
                                        if (zowe.certificate?.truststore?.type == "JCERACFKS") {
                                           return [ zowe.certificate.truststore.file ];
                                        } else if(zowe.certificate?.pem?.certificateAuthorities) {
-                                          return [zowe.certificate.pem.certificateAuthorities];
+                                          if (Array.isArray(zowe.certificate.pem.certificateAuthorities)) {
+                                            return zowe.certificate.pem.certificateAuthorities;
+                                          } else {
+                                            return zowe.certificate.pem.certificateAuthorities.split(',');
+                                          }
                                         } else { return ["../defaults/serverConfig/apiml-localca.cer"]; } };
                                   a() }}'
       loopbackAddress: "${{ function a(){ if (process.env.ZOWE_LOOPBACK_ADDRESS) { return process.env.ZOWE_LOOPBACK_ADDRESS; } else { return undefined; } }; a() }}"


### PR DESCRIPTION
This PR fixes https://github.com/zowe/zlux/issues/976 by updating the defaults to handle 3 different cases in the pem CA section:
1) if the section is an array, return it without wrapping in an array (was a bug, ended up with 2 arrays)
2) if the section isnt an array, its a string which may be many entries if it has a `,`. so, do a split(,), which even if there's just 1 entry you still get an array.