### PR TITLE
Fixed env merging to wrong part of yaml heirarchy

### DIFF
--- a/bin/install-app.sh
+++ b/bin/install-app.sh
@@ -30,10 +30,13 @@ if [ -n "${ZWE_zowe_workspaceDirectory}" -a -n "${ZWE_zowe_runtimeDirectory}" ];
       ZLUX_CONTAINER_MODE=1  
       INSTALL_NO_NODE=1  
     fi
+    if [ ! -d "${COMPONENT_HOME}/share/zlux-app-server" ]; then
+      COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/app-server
+    fi
   fi
+  zlux_path="$COMPONENT_HOME/share"
 
   if [ -z "$INSTALL_NO_NODE" ]; then
-    zlux_path="$COMPONENT_HOME/share"
     setVars
     if [ ! -e "${ZWE_zowe_workspaceDirectory}/app-server/plugins/org.zowe.zlux.json" ]; then
       cd ${zlux_path}/zlux-app-server/lib

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -57,8 +57,22 @@ components:
       loopbackAddress: "${{ function a(){ if (process.env.ZOWE_LOOPBACK_ADDRESS) { return process.env.ZOWE_LOOPBACK_ADDRESS; } else { return undefined; } }; a() }}"
       mediationLayer:
         server:
-          hostname: ${{ zowe.externalDomains[0] }}
-          gatewayHostname: ${{ zowe.externalDomains[0] }}
+          # if ZWE_DISCOVERY_SERVICES_LIST exists, its more accurate than zowe.externalDomains, as that doesn't handle containers well.
+          # if exists, its in the format of "https://discovery-0.discovery-service.zowe.svc.cluster.local:7553/eureka/"
+          hostname: '${{ function a() {
+                         if (process.env.ZWE_DISCOVERY_SERVICES_LIST) {
+                           return process.env.ZWE_DISCOVERY_SERVICES_LIST.split(",")[0].split("/")[2].split(":")[0];
+                         } else { 
+                           return zowe.externalDomains[0] } };
+                     a() }}'
+          # usually, externalDomains is where gateway is. But on containers, this isnt accessible to containers, so
+          # HACK: special var ZWE_GATEWAY_HOST is used instead
+          gatewayHostname: '${{ function a() {
+                                if (process.env.ZWED_node_container=="true" && process.env.ZWE_GATEWAY_HOST) {
+                                  return process.env.ZWE_GATEWAY_HOST;
+                                } else {
+                                  return zowe.externalDomains[0] } };
+                            a() }}'
           port: ${{ components.discovery.port }}
           gatewayPort: ${{ zowe.externalPort }}
           isHttps: true

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -62,13 +62,13 @@ if(process.env.overrideFileConfig !== "false"){
     if (cluster.isMaster) {
       console.log('\nZWED5015I - Processed environment variables:\n'+JSON.stringify(envConfig, null, 2));
     }
-    configJSON = mergeUtils.deepAssign(configJSON, envConfig);
+    configJSON = mergeUtils.deepAssign(configJSON.components['app-server'], envConfig);
   }
   if (userInput.D) {
     if (cluster.isMaster) {
       console.log('\nZWED5016I - Processed -D arguments:\n'+JSON.stringify(userInput.D, null, 2));
     }
-    configJSON = mergeUtils.deepAssign(configJSON, userInput.D);
+    configJSON = mergeUtils.deepAssign(configJSON.components['app-server'], userInput.D);
   }
 } else {
   console.log("ZWED5017I - Using config JSON, discarding CLI args");


### PR DESCRIPTION
If a user had set vars such as ZWED_agent_host, ZWED_agent_https_port, then they would not be applied in app-server correctly because in v2.10 the app-server went from reading just its own components section, to now reading the entire yaml (2 levels up). so, the references on where to merge env vars into the yaml, were 2 levels off (.components.app-server)