### PR TITLE
Fix zss connection in container

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -23,30 +23,28 @@ fi
 
 cd ${COMPONENT_HOME}/share/zlux-app-server/bin
 
-if [ -n "$ZWE_components_app_server_node_mediationLayer_enabled" -a -z "$ZWE_components_app_server_agent_mediationLayer_enabled" ]; then
-  if [ "${ZWE_RUN_ON_ZOS}" != "true" ]; then
-    zss_def_template="zss.apiml_static_reg.yaml.template"
-    zss_configured=false
-    if [ -n "${ZWE_components_app_server_agent_https_port}" ]; then
-      export ZSS_PORT="${ZWE_components_app_server_agent_https_port}"
-      export ZSS_PROTOCOL=https
-      zss_configured=true
-    elif [ -n "${ZWED_components_app_server_agent_http_port}" ]; then 
-      export ZSS_PORT="${ZWE_components_app_server_http_port}"
-      export ZSS_PROTOCOL=http
-      zss_configured=true
-    fi
-
-    if [ "${zss_configured}" = "true" ] && [ -n "${ZWE_STATIC_DEFINITIONS_DIR}" ]; then
-      zss_registration_yaml=${ZWE_STATIC_DEFINITIONS_DIR}/zss.apiml_static_reg_yaml_template.${ZWE_CLI_PARAMETER_HA_INSTANCE}.yml
-      zss_def="../${zss_def_template}"
-      zss_parsed_def=$( ( echo "cat <<EOF" ; cat "${zss_def}" ; echo ; echo EOF ) | sh 2>&1)
-      echo "${zss_parsed_def}" > "${zss_registration_yaml}"
-      chmod 770 "${zss_registration_yaml}"
-    fi
+if [ "$ZWE_components_gateway_enabled" == "true" ]; then
+  if [ "$ZWE_components_zss_enabled" == "true" ]; then
+    if [ "${ZWE_RUN_ON_ZOS}" != "true" ]; then
+      zss_def_template="zss.apiml_static_reg.yaml.template"
+      export ZSS_PORT="${ZWE_components_zss_port}"
+      if [ "${ZWE_components_zss_tls}" != "false" ]; then
+        export ZSS_PROTOCOL=https
+      else
+        export ZSS_PROTOCOL=http
+      fi
   
-    unset ZSS_PORT
-    unset ZSS_PROTOCOL
+      if [ -n "${ZWE_STATIC_DEFINITIONS_DIR}" ]; then
+        zss_registration_yaml=${ZWE_STATIC_DEFINITIONS_DIR}/zss.apiml_static_reg_yaml_template.${ZWE_CLI_PARAMETER_HA_INSTANCE}.yml
+        zss_def="../${zss_def_template}"
+        zss_parsed_def=$( ( echo "cat <<EOF" ; cat "${zss_def}" ; echo ; echo EOF ) | sh 2>&1)
+        echo "${zss_parsed_def}" > "${zss_registration_yaml}"
+        chmod 770 "${zss_registration_yaml}"
+      fi
+    
+      unset ZSS_PORT
+      unset ZSS_PROTOCOL
+    fi
   fi
 fi
 


### PR DESCRIPTION
Configure script was relying on env vars that are unlikely to exist (typically derived, and containers not reading defaults.yaml) so zss was not set up properly. Switch to env vars that are more likely to exist (typically in zowe.yaml). Causes slight logic duplication, but should work for more people.