### PR TITLE
Feature/automate changelog note

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -103,10 +103,10 @@ jobs:
               sed -i "$ANCHOR_LINE a\\
               \n## $VERSION\n- $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})\n" CHANGELOG.md
             fi
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
+            git config --global user.email "zowe-robot@users.noreply.github.com"
+            git config --global user.name "Zowe Robot"
             git add CHANGELOG.md
-            git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
+            git commit -s -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
             git push
           fi
       - name: check for changes

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -69,9 +69,6 @@ jobs:
         run: |
           echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
 
-      - name: Remove copy-repo
-        if: always()
-        run: rm -r copy-repo
 
 
     update_changelog:

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -44,57 +44,72 @@ jobs:
           github-repo: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  check_changelog:
+  update-changelog:
     runs-on: ubuntu-latest
     outputs:
-      was_updated: ${{ steps.check.outputs.was_updated }}
+      was_updated: ${{ steps.check-change.outputs.change_detected }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
-          fetch-depth: 2
+          ref: ${{ github.head_ref }}
 
-      - name: Check if CHANGELOG.md was updated
-        id: check
+      - name: Extract changelog info
+        id: extract-changelog
         run: |
-          if git diff --name-only HEAD^ HEAD | grep 'CHANGELOG.md'; then
-            echo "CHANGELOG.md was updated in the last commit."
-            echo "::set-output name=was_updated::true"
+          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+
+          # Check if "changelog:" exists in PR description
+          if [[ $PR_DESCRIPTION == *"CHANGELOG:"* ]]; then
+
+            # Extract text after "changelog:"
+            CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
+
+            echo "Extracted changelog: $CHANGELOG_TEXT"
+            echo "::set-output name=changelog::$CHANGELOG_TEXT"
           else
-            echo "CHANGELOG.md was NOT updated in the last commit."
-            echo "::set-output name=was_updated::false"
+            echo "No changelog information found in PR description please add the changelog note"
+            exit 1
           fi
-      - name: Check if CHANGELOG is Updated and if not updated pass to update_changelog
-        if: ${{ steps.check.outputs.was_updated != 'true' }}
-        run: |
-          echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
 
-  update_changelog:
-      needs: check_changelog
+      - name: Check PR body against changelog
+        run: |
+          if ! grep -Fq "${{ steps.extract-changelog.outputs.changelog }}" CHANGELOG.md; then
+            LINE_NUMBER=$(awk '/^##/{print NR; exit}' CHANGELOG.md)
+            sed -i "${LINE_NUMBER} a- ${{ steps.extract-changelog.outputs.changelog }} . (#${{ github.event.pull_request.number }})" CHANGELOG.md
+            # echo "${{ steps.extract-changelog.outputs.changelog }}" >> CHANGELOG.md
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git add CHANGELOG.md
+            git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
+            git push
+          fi
+
+      - name: check for changes
+        id: check-change
+        run: |
+          if git diff --name-only HEAD^ HEAD | grep 'changelog.md'; then
+            echo "No Changes detected, setting flag to false"
+            echo "::set-output name=change_detected::false"
+          else
+            echo "::set-output name=change_detected::true"
+          fi
+
+    check_changelog:
+      needs: update-changelog
       runs-on: ubuntu-latest
-      if: ${{ needs.check_changelog.outputs.was_updated == 'false' }}
       steps:
         - name: Checkout code
           uses: actions/checkout@v2
-          with:
-            fetch-depth: 2
 
-        - name: Get commit message
-          run: echo "COMMIT_MESSAGE=$(git log --format=%B -n 1)" >> $GITHUB_ENV
-
-
-        - name: Append commit to Changelog
+        - name: Verify Changelog update
           run: |
-            echo "CHANGELOG: $COMMIT_MESSAGE" >> CHANGELOG.md
-            echo "${{ steps.check-changelog.outputs.was_updated}}"
-
-        - name: Commit and push if it changed
-          run: |
-            git diff
-            git config --global user.email "actions@github.com"
-            git config --global user.name "GitHub Actions"
-            git commit -am "Update Changelog" -m "$COMMIT_MESSAGE" && echo ::set-output name=push::true || echo "No changes to commit"
-            git push origin || echo "No changes to push"
+            if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
+              echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
+              exit 1
+            else
+              echo "changelog was updated successfully."
+            fi
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -82,7 +82,7 @@ jobs:
             echo "::set-output name=version::$VERSION"
           else
             echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
-            To re-run the action, just pushed/commit the changes along with PR description, it will automatically triggered by sync."
+            To re-run the action, just make a push or commit after updating the PR description or updating the changelog via a manual file changing commit."
             exit 1
           fi
       - name: Check PR body against changelog
@@ -92,7 +92,7 @@ jobs:
           # Check if version exists in CHANGELOG.md
             if grep -q "## ${{ steps.extract-changelog.outputs.version }}" CHANGELOG.md; then
               # Append PR description to existing version
-              sed -i "/## ${{ steps.extract-changelog.outputs.version }}/ a- ${{ steps.extract-changelog.outputs.changelog }} . (#${{ github.event.pull_request.number }})" CHANGELOG.md
+              sed -i "/## ${{ steps.extract-changelog.outputs.version }}/ a- ${{ steps.extract-changelog.outputs.changelog }} (#${{ github.event.pull_request.number }})" CHANGELOG.md
             else
               # Append new version and PR description
               echo "$(awk '/All notable changes to the Zlux App Server package will be documented in this file\./ {

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -48,43 +48,66 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       was_updated: ${{ steps.check-change.outputs.change_detected }}
+      check_commit: ${{ steps.check-changelog.outputs.check_commit }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
+      - name: Check for updated CHANGELOG.md using git
+        id: check-changelog
+        run: |
+          if git diff --name-only origin/${{ github.base_ref }} | grep -q "^CHANGELOG.md$"; then
+            echo "CHANGELOG.md has been updated."
+            echo "::set-output name=check_commit::true"
+          else
+            echo "ERROR: CHANGELOG.md has not been updated."
+            echo "::set-output name=check_commit::false"
+          fi
       - name: Extract changelog info
+        if: steps.check-changelog.outputs.check_commit == 'false'
         id: extract-changelog
         run: |
           PR_DESCRIPTION="${{ github.event.pull_request.body }}"
-
           # Check if "changelog:" exists in PR description
-          if [[ $PR_DESCRIPTION == *"CHANGELOG:"* ]]; then
-
+          if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
             # Extract text after "changelog:"
             CHANGELOG_TEXT=$(echo $PR_DESCRIPTION | sed -n 's/.*CHANGELOG: \(.*\)/\1/p')
-
+            # Extract VERSION: from PR description
+            VERSION=$(echo "$PR_DESCRIPTION" | grep -oP 'VERSION:\s*\Kv\d+\.\d+\.\d+')
             echo "Extracted changelog: $CHANGELOG_TEXT"
             echo "::set-output name=changelog::$CHANGELOG_TEXT"
+            echo "::set-output name=version::$VERSION"
           else
-            echo "No changelog information found in PR description please add the changelog note"
+            echo "No changelog and version information found in PR description please add them"
             exit 1
           fi
-
       - name: Check PR body against changelog
+        if: steps.check-changelog.outputs.check_commit == 'false'
         run: |
+          set -eux
           if ! grep -Fq "${{ steps.extract-changelog.outputs.changelog }}" CHANGELOG.md; then
-            LINE_NUMBER=$(awk '/^##/{print NR; exit}' CHANGELOG.md)
-            sed -i "${LINE_NUMBER} a- ${{ steps.extract-changelog.outputs.changelog }} . (#${{ github.event.pull_request.number }})" CHANGELOG.md
-            # echo "${{ steps.extract-changelog.outputs.changelog }}" >> CHANGELOG.md
+          # Check if version exists in CHANGELOG.md
+            if grep -q "## ${{ steps.extract-changelog.outputs.version }}" CHANGELOG.md; then
+              # Append PR description to existing version
+              sed -i "/## ${{ steps.extract-changelog.outputs.version }}/ a- ${{ steps.extract-changelog.outputs.changelog }} . (#${{ github.event.pull_request.number }})" CHANGELOG.md
+            else
+              # Append new version and PR description
+              echo "$(awk '/All notable changes to the Zlux App Server package will be documented in this file\./ {
+                print
+                print "\n## " "${{ steps.extract-changelog.outputs.version }}"
+                print "- " "${{ steps.extract-changelog.outputs.changelog }}" " (#${{ github.event.pull_request.number }})"
+                next
+              } 1' CHANGELOG.md)" > CHANGELOG.md
+           fi
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
             git add CHANGELOG.md
             git commit -m "Update changelog with PR #${{ github.event.pull_request.number }} description"
             git push
           fi
-
       - name: check for changes
         id: check-change
         run: |
@@ -95,21 +118,21 @@ jobs:
             echo "::set-output name=change_detected::true"
           fi
 
-  check_changelog:
-    needs: update-changelog
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+    check_changelog:
+      needs: update-changelog
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
 
-      - name: Verify Changelog update
-        run: |
-          if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
-            echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
-            exit 1
-          else
-            echo "changelog was updated successfully."
-          fi
+        - name: Verify Changelog update
+          run: |
+            if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
+              echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
+              exit 1
+            else
+              echo "changelog was updated successfully."
+            fi
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -95,21 +95,21 @@ jobs:
             echo "::set-output name=change_detected::true"
           fi
 
-    check_changelog:
-      needs: update-changelog
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v2
+  check_changelog:
+    needs: update-changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-        - name: Verify Changelog update
-          run: |
-            if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
-              echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
-              exit 1
-            else
-              echo "changelog was updated successfully."
-            fi
+      - name: Verify Changelog update
+        run: |
+          if [ "${{ needs.update-changelog.outputs.was_updated }}" != "true" ]; then
+            echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
+            exit 1
+          else
+            echo "changelog was updated successfully."
+          fi
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -69,9 +69,7 @@ jobs:
         run: |
           echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
 
-
-
-    update_changelog:
+  update_changelog:
       needs: check_changelog
       runs-on: ubuntu-latest
       if: ${{ needs.check_changelog.outputs.was_updated == 'false' }}
@@ -97,7 +95,7 @@ jobs:
             git config --global user.name "GitHub Actions"
             git commit -am "Update Changelog" -m "$COMMIT_MESSAGE" && echo ::set-output name=push::true || echo "No changes to commit"
             git push origin || echo "No changes to push"
-        
+
   build:
     runs-on: ubuntu-latest
     needs: check-permission
@@ -113,7 +111,7 @@ jobs:
           key: ${{ runner.os }}-build-cache-node-modules-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-cache-node-modules-
-      
+
       - name: '[Prep 2] Setup Node'
         uses: actions/setup-node@v2
         with:
@@ -149,6 +147,7 @@ jobs:
           pax-ssh-username: ${{ secrets.SSH_MARIST_USERNAME }}
           pax-ssh-password: ${{ secrets.SSH_MARIST_RACF_PASSWORD }}
           pax-name: zlux-core
-          
+
       - name: '[Prep 7] deploy'
         uses: zowe-actions/zlux-builds/core/deploy@v2.x/main
+

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -86,7 +86,7 @@ jobs:
         
   build:
     runs-on: ubuntu-latest
-    needs: check_changelog
+    needs: check-permission
     steps:
       - name: '[Prep 1] Cache node modules'
         uses: actions/cache@v2

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -81,8 +81,12 @@ jobs:
       - name: Check if CHANGELOG is Updated and Abort if not updated
         if: steps.set-flag.outputs.file-flag != 'true'
         run: |
-          echo "CHANGELOG not added. Please add the CHANGELOG in the CHANGELOG.md file"
+          echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
           exit 1
+
+      - name: Remove copy-repo
+        if: always()
+        run: rm -r copy-repo
         
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -81,7 +81,7 @@ jobs:
             echo "::set-output name=changelog::$CHANGELOG_TEXT"
             echo "::set-output name=version::$VERSION"
           else
-            echo -e "No changelog and version information found in PR description please add them\n Expected Format VERSION:vX.XX.X\n CHANGELOG:This is changelog note\n
+            echo -e "No changelog and version information found in PR description please add them.\n Expected Format VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
             To re-run the action, just pushed/commit the changes along with PR description, it will automatically triggered by sync."
             exit 1
           fi

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -46,24 +46,44 @@ jobs:
 
   check_changelog:
     runs-on: ubuntu-latest
-    needs: check-permission
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        
-      - name: Check if CHANGELOG is added
-        id: changed-files-yaml
-        uses: tj-actions/changed-files@v37
         with:
-          files_yaml: |
-            doc:
-              - CHANGELOG.md
+            path: copy-repo
+            fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
 
-      - name: Abort the workflow if CHANGELOG is not added
-        if: steps.changed-files-yaml.outputs.doc_any_changed != 'true'
+      - name: Get changed files
+        id: changed-files
         run: |
-          echo "CHANGELOG
+            cd copy-repo
+            if ${{ github.event_name == 'pull_request' }}; then
+                echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+            else
+                echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
+            fi
 
+      - name: List changed files
+        id: set-flag
+        run: |
+            cd copy-repo
+            for file in ${{ steps.changed-files.outputs.changed_files }}; do
+                echo "$file was changed"
+                if [[ $file == "CHANGELOG.md" ]]
+                then
+                  echo "file-flag=true" >> $GITHUB_OUTPUT
+                  break;
+                else
+                  echo "file-flag=false" >> $GITHUB_OUTPUT
+                fi
+            done
+
+      - name: Check if CHANGELOG is Updated and Abort if not updated
+        if: steps.set-flag.outputs.file-flag != 'true'
+        run: |
+          echo "CHANGELOG not added. Please add the CHANGELOG in the CHANGELOG.md file"
+          exit 1
+        
   build:
     runs-on: ubuntu-latest
     needs: check_changelog

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Check if CHANGELOG is Updated and if not updated pass to update_changelog
         if: ${{ steps.check.outputs.was_updated != 'true' }}
         run: |
-          echo "CHANGELOG not added. Please add the CHANGELOG in the CHANGELOG.md file"
+          echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
 
       - name: Remove copy-repo
         if: always()

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -44,11 +44,30 @@ jobs:
           github-repo: ${{ github.repository }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-  build:
+  check_changelog:
     runs-on: ubuntu-latest
     needs: check-permission
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        
+      - name: Check if CHANGELOG is added
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v37
+        with:
+          files_yaml: |
+            doc:
+              - CHANGELOG.md
 
+      - name: Abort the workflow if CHANGELOG is not added
+        if: steps.changed-files-yaml.outputs.doc_any_changed != 'true'
+        run: |
+          echo "CHANGELOG
+
+  build:
+    runs-on: ubuntu-latest
+    needs: check_changelog
+    steps:
       - name: '[Prep 1] Cache node modules'
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -81,7 +81,7 @@ jobs:
             echo "::set-output name=changelog::$CHANGELOG_TEXT"
             echo "::set-output name=version::$VERSION"
           else
-            echo -e "No changelog and version information found in PR description please add them.\n Expected Format VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
+            echo -e "No changelog and version information found in PR description please add them.\n Expected Format:\n VERSION:vX.XX.X\n CHANGELOG:This is changelog note.\n
             To re-run the action, just pushed/commit the changes along with PR description, it will automatically triggered by sync."
             exit 1
           fi

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -118,7 +118,7 @@ jobs:
             echo "::set-output name=change_detected::true"
           fi
 
-    check_changelog:
+  check_changelog:
       needs: update-changelog
       runs-on: ubuntu-latest
       steps:

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -46,47 +46,60 @@ jobs:
 
   check_changelog:
     runs-on: ubuntu-latest
+    outputs:
+      was_updated: ${{ steps.check.outputs.was_updated }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         with:
-            path: copy-repo
-            fetch-depth: ${{ github.event_name == 'pull_request' && 2 || 0 }}
+          fetch-depth: 2
 
-      - name: Get changed files
-        id: changed-files
+      - name: Check if CHANGELOG.md was updated
+        id: check
         run: |
-            cd copy-repo
-            if ${{ github.event_name == 'pull_request' }}; then
-                echo "changed_files=$(git diff --name-only -r HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
-            else
-                echo "changed_files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | xargs)" >> $GITHUB_OUTPUT
-            fi
-
-      - name: List changed files
-        id: set-flag
+          if git diff --name-only HEAD^ HEAD | grep 'CHANGELOG.md'; then
+            echo "CHANGELOG.md was updated in the last commit."
+            echo "::set-output name=was_updated::true"
+          else
+            echo "CHANGELOG.md was NOT updated in the last commit."
+            echo "::set-output name=was_updated::false"
+          fi
+      - name: Check if CHANGELOG is Updated and if not updated pass to update_changelog
+        if: ${{ steps.check.outputs.was_updated != 'true' }}
         run: |
-            cd copy-repo
-            for file in ${{ steps.changed-files.outputs.changed_files }}; do
-                echo "$file was changed"
-                if [[ $file == "CHANGELOG.md" ]]
-                then
-                  echo "file-flag=true" >> $GITHUB_OUTPUT
-                  break;
-                else
-                  echo "file-flag=false" >> $GITHUB_OUTPUT
-                fi
-            done
-
-      - name: Check if CHANGELOG is Updated and Abort if not updated
-        if: steps.set-flag.outputs.file-flag != 'true'
-        run: |
-          echo "CHANGELOG.md not updated, please update CHANGELOG.md with the changes made in the pull request"
-          exit 1
+          echo "CHANGELOG not added. Please add the CHANGELOG in the CHANGELOG.md file"
 
       - name: Remove copy-repo
         if: always()
         run: rm -r copy-repo
+
+
+    update_changelog:
+      needs: check_changelog
+      runs-on: ubuntu-latest
+      if: ${{ needs.check_changelog.outputs.was_updated == 'false' }}
+      steps:
+        - name: Checkout code
+          uses: actions/checkout@v2
+          with:
+            fetch-depth: 2
+
+        - name: Get commit message
+          run: echo "COMMIT_MESSAGE=$(git log --format=%B -n 1)" >> $GITHUB_ENV
+
+
+        - name: Append commit to Changelog
+          run: |
+            echo "CHANGELOG: $COMMIT_MESSAGE" >> CHANGELOG.md
+            echo "${{ steps.check-changelog.outputs.was_updated}}"
+
+        - name: Commit and push if it changed
+          run: |
+            git diff
+            git config --global user.email "actions@github.com"
+            git config --global user.name "GitHub Actions"
+            git commit -am "Update Changelog" -m "$COMMIT_MESSAGE" && echo ::set-output name=push::true || echo "No changes to commit"
+            git push origin || echo "No changes to push"
         
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -81,13 +81,13 @@ jobs:
             echo "::set-output name=changelog::$CHANGELOG_TEXT"
             echo "::set-output name=version::$VERSION"
           else
-            echo "No changelog and version information found in PR description please add them"
+            echo -e "No changelog and version information found in PR description please add them\n Expected Format VERSION:vX.XX.X\n CHANGELOG:This is changelog note\n
+            To re-run the action, just pushed/commit the changes along with PR description, it will automatically triggered by sync."
             exit 1
           fi
       - name: Check PR body against changelog
         if: steps.check-changelog.outputs.check_commit == 'false'
         run: |
-          set -eux
           if ! grep -Fq "${{ steps.extract-changelog.outputs.changelog }}" CHANGELOG.md; then
           # Check if version exists in CHANGELOG.md
             if grep -q "## ${{ steps.extract-changelog.outputs.version }}" CHANGELOG.md; then

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -88,20 +88,21 @@ jobs:
       - name: Check PR body against changelog
         if: steps.check-changelog.outputs.check_commit == 'false'
         run: |
-          if ! grep -Fq "${{ steps.extract-changelog.outputs.changelog }}" CHANGELOG.md; then
-          # Check if version exists in CHANGELOG.md
-            if grep -q "## ${{ steps.extract-changelog.outputs.version }}" CHANGELOG.md; then
+          ESCAPED_CHANGELOG="${{ steps.extract-changelog.outputs.changelog }}"
+          ESCAPED_CHANGELOG=$(echo "$ESCAPED_CHANGELOG" | sed "s/'/\\\\'/g")
+          VERSION="${{ steps.extract-changelog.outputs.version }}"
+          
+          if ! grep -Fq "$ESCAPED_CHANGELOG" CHANGELOG.md; then
+            # Check if version exists in CHANGELOG.md
+            if grep -q "^## $VERSION" CHANGELOG.md; then
               # Append PR description to existing version
-              sed -i "/## ${{ steps.extract-changelog.outputs.version }}/ a- ${{ steps.extract-changelog.outputs.changelog }} (#${{ github.event.pull_request.number }})" CHANGELOG.md
+              sed -i "/^## $VERSION/a - $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})" CHANGELOG.md
             else
               # Append new version and PR description
-              echo "$(awk '/All notable changes to the Zlux App Server package will be documented in this file\./ {
-                print
-                print "\n## " "${{ steps.extract-changelog.outputs.version }}"
-                print "- " "${{ steps.extract-changelog.outputs.changelog }}" " (#${{ github.event.pull_request.number }})"
-                next
-              } 1' CHANGELOG.md)" > CHANGELOG.md
-           fi
+              ANCHOR_LINE=$(awk '/All notable changes to the Zlux App Server package will be documented in this file\./ {print NR}' CHANGELOG.md)
+              sed -i "$ANCHOR_LINE a\\
+              \n## $VERSION\n- $ESCAPED_CHANGELOG (#${{ github.event.pull_request.number }})\n" CHANGELOG.md
+            fi
             git config --local user.email "action@github.com"
             git config --local user.name "GitHub Action"
             git add CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,4 +82,4 @@ All notable changes to the Zlux App Server package will be documented in this fi
 
 - Add v1.12 update script for replacing all bundled plugin references with ones that use $ROOT_DIR environment variable
 - Change Scripts to work with independent zss component
-- Add v1.12 update script for removing apiml-auth if it is not being explicitly used
+- Add v1.12 update script for removing apiml-auth if it is not being explicitly used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v2.11.0
+- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. . (#278)
 
 - Bugfix: The server couldn't load more than one certificate authority specified within the zowe.certificate.pem.certificateAuthorities section under any condition. Now, it is supported regardless of if the section is an array or a comma-separated string. (#266)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v2.11.0
-- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not.(#278)
 - Bugfix: The server couldn't load more than one certificate authority specified within the zowe.certificate.pem.certificateAuthorities section under any condition. Now, it is supported regardless of if the section is an array or a comma-separated string. (#266)
 
 ## v2.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v2.11.0
-- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not. . (#278)
-
+- This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not.(#278)
 - Bugfix: The server couldn't load more than one certificate authority specified within the zowe.certificate.pem.certificateAuthorities section under any condition. Now, it is supported regardless of if the section is an array or a comma-separated string. (#266)
 
 ## v2.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,4 +82,4 @@ All notable changes to the Zlux App Server package will be documented in this fi
 
 - Add v1.12 update script for replacing all bundled plugin references with ones that use $ROOT_DIR environment variable
 - Change Scripts to work with independent zss component
-- Add v1.12 update script for removing apiml-auth if it is not being explicitly used.
+- Add v1.12 update script for removing apiml-auth if it is not being explicitly used

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This program and the accompanying materials are
+ This program and the accompanying materials are
 made available under the terms of the Eclipse Public License v2.0 which accompanies
 this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
 


### PR DESCRIPTION
VERSION: v2.11.0
CHANGELOG: This action making a CHANGELOG note via special syntax from the GitHub PR commit message, like it could automatically update CHANGELOG.md with the message. First job checks if PR body has changelog note or not if it's not there then it asked them to add it and second job is to check if changelog note has been added in changelog.md file or not.