### PR TITLE
check changelog when its a PR

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -45,6 +45,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   update-changelog:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       was_updated: ${{ steps.check-change.outputs.change_detected }}
@@ -120,6 +121,7 @@ jobs:
           fi
 
   check_changelog:
+      if: github.event_name == 'pull_request'
       needs: update-changelog
       runs-on: ubuntu-latest
       steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v2.11.0
+- Small update in changelog action, it will check and update changelog when its a PR.
 - Bugfix: The server couldn't load more than one certificate authority specified within the zowe.certificate.pem.certificateAuthorities section under any condition. Now, it is supported regardless of if the section is an array or a comma-separated string. (#266)
 
 ## v2.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v2.11.0
-- Small update in changelog action, it will check and update changelog when its a PR.
+
 - Bugfix: The server couldn't load more than one certificate authority specified within the zowe.certificate.pem.certificateAuthorities section under any condition. Now, it is supported regardless of if the section is an array or a comma-separated string. (#266)
 
 ## v2.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v2.11.0
-- Small update in changelog action, it will check and update changelog when its a PR.
 - Bugfix: The server couldn't load more than one certificate authority specified within the zowe.certificate.pem.certificateAuthorities section under any condition. Now, it is supported regardless of if the section is an array or a comma-separated string. (#266)
 
 ## v2.10.0


### PR DESCRIPTION
Small update in changelog action, it will check and update changelog when its a PR, Currently some builds show that they are failing because of the changelog, the changelog logic shouldn't run unless if its a pull request. 