### PR TITLE
Allow component upgrades to relocate own plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Zlux App Server Changelog
 
 All notable changes to the Zlux App Server package will be documented in this file.
+    
+## v2.12.0
+- enhancement: new versions of components can change the location of their plugins, as the app-server will now re-inspect the plugin locations on each startup. (#280)
+
 
 ## v2.11.0
 

--- a/bin/init/plugins-init.js
+++ b/bin/init/plugins-init.js
@@ -38,7 +38,7 @@ function deleteFile(path) {
 }
 
 function registerPlugin(pluginPath, pluginDefinition) {
-  const pointerPath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
+  const pointerPath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`; 
   let location, relativeTo;
   if (pluginPath.startsWith(runtimeDirectory)) {
     relativeTo = "$ZWE_zowe_runtimeDirectory";

--- a/bin/init/plugins-init.js
+++ b/bin/init/plugins-init.js
@@ -39,32 +39,26 @@ function deleteFile(path) {
 
 function registerPlugin(pluginPath, pluginDefinition) {
   const pointerPath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
-  if (fs.fileExists(pointerPath)) {
-    //in case of upgrade
-    registerApp2App(pluginPath, pluginDefinition.identifier, pluginDefinition.pluginVersion);
-    return true;
-  } else {
-    let location, relativeTo;
-    if (pluginPath.startsWith(runtimeDirectory)) {
-      relativeTo = "$ZWE_zowe_runtimeDirectory";
-      location = pluginPath.substring(runtimeDirectory.length);
-      if (location.startsWith('/')) {
-        location = location.substring(1);
-      }
-
-      xplatform.storeFileUTF8(pointerPath, xplatform.AUTO_DETECT, JSON.stringify({
-        "identifier": pluginDefinition.identifier,
-        "pluginLocation": location,
-        "relativeTo": relativeTo
-      }, null, 2));
-    } else {
-      xplatform.storeFileUTF8(pointerPath, xplatform.AUTO_DETECT, JSON.stringify({
-        "identifier": pluginDefinition.identifier,
-        "pluginLocation": pluginPath
-      }, null, 2));
+  let location, relativeTo;
+  if (pluginPath.startsWith(runtimeDirectory)) {
+    relativeTo = "$ZWE_zowe_runtimeDirectory";
+    location = pluginPath.substring(runtimeDirectory.length);
+    if (location.startsWith('/')) {
+      location = location.substring(1);
     }
-    registerApp2App(pluginPath, pluginDefinition.identifier, pluginDefinition.pluginVersion);
+    
+    xplatform.storeFileUTF8(pointerPath, xplatform.AUTO_DETECT, JSON.stringify({
+      "identifier": pluginDefinition.identifier,
+      "pluginLocation": location,
+      "relativeTo": relativeTo
+    }, null, 2));
+  } else {
+    xplatform.storeFileUTF8(pointerPath, xplatform.AUTO_DETECT, JSON.stringify({
+      "identifier": pluginDefinition.identifier,
+      "pluginLocation": pluginPath
+    }, null, 2));
   }
+  registerApp2App(pluginPath, pluginDefinition.identifier, pluginDefinition.pluginVersion);
 }
 
 

--- a/bin/init/plugins-init.js
+++ b/bin/init/plugins-init.js
@@ -46,7 +46,7 @@ function registerPlugin(pluginPath, pluginDefinition) {
     if (location.startsWith('/')) {
       location = location.substring(1);
     }
-    
+
     xplatform.storeFileUTF8(pointerPath, xplatform.AUTO_DETECT, JSON.stringify({
       "identifier": pluginDefinition.identifier,
       "pluginLocation": location,


### PR DESCRIPTION
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] New and existing unit tests pass locally with my changes
- [x] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, or describe a test method below




VERSION: v2.12.0
CHANGELOG: enhancement: new versions of components can change the location of their plugins, as the app-server will now re-inspect the plugin locations on each startup.

## Testing
To test this you can reorganize a component you have to change the location of a plugin within.
In the example below, i previously had the plugin at '.', and moved it to 'newlocation'.
I inspected that the code worked by reading the json at the bottom after a zowe restart, and it correctly had 'newlocation'.
![location-change](https://github.com/zowe/zlux-app-server/assets/30730276/1980f7f7-b820-4b6f-b31a-952be734e8da)
