### PR TITLE
Add definition for minTls and maxTls

### DIFF
--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -58,7 +58,7 @@
               "type": "string",
               "enum": ["TLSv1.2", "TLSv1.3"],
               "default": "TLSv1.2",
-              "description": "Minimum TLS version allowed for network connections, and less than maxTls."
+              "description": "Minimum TLS version allowed for network connections, and less than or equal to maxTls."
             },
             "ciphers": {
               "oneOf": [

--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -48,6 +48,18 @@
               "deprecated": true,
               "description": "Passes through the secureProtocol attribute to TLS calls of nodeJS, as defined within https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions"
             },
+            "minTls": {
+              "type": "string",
+              "enum": ["TLSv1.2", "TLSv1.3"],
+              "default": "TLSv1.3",
+              "description": "Maximum TLS version allowed for network connections."
+            },
+            "minTls": {
+              "type": "string",
+              "enum": ["TLSv1.2", "TLSv1.3"],
+              "default": "TLSv1.2",
+              "description": "Minimum TLS version allowed for network connections, and less than maxTls."
+            },
             "ciphers": {
               "oneOf": [
                 { "$ref": "#/$defs/nodejsDefaultCiphers" },

--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -48,7 +48,7 @@
               "deprecated": true,
               "description": "Passes through the secureProtocol attribute to TLS calls of nodeJS, as defined within https://nodejs.org/api/tls.html#tlscreatesecurecontextoptions"
             },
-            "minTls": {
+            "maxTls": {
               "type": "string",
               "enum": ["TLSv1.2", "TLSv1.3"],
               "default": "TLSv1.3",


### PR DESCRIPTION
In PR #284 setting min and max TLS settings was introduced, and worked, but the schema didn't say this ability existed. So, just adding the missing description.