### PR TITLE
Add schema and default for getting all discovery servers instead of just one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v2.14.0
+- Enhancement: Updated schema to specify multiple discovery servers.
+
 ## v2.13.0
 - Enhancement: Updated schema to allow cipher customization in IANA format. (#284)
 - Enhancement: Updated schema to allow curve customization. (#284)

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -102,12 +102,21 @@ components:
       mediationLayer:
         server:
           # strange but true: to contact discovery in a container, instead reach for the gateway hostname.
+          # DEPRECATED. Use discoveryUrls instead.
           hostname: '${{ function a() {
                          if (process.env.ZWE_RUN_IN_CONTAINER=="true" && process.env.ZWE_GATEWAY_HOST) {
                            return process.env.ZWE_GATEWAY_HOST;
                          } else { 
                            return zowe.externalDomains[0] } };
                      a() }}'
+          discoveryUrls: '${{ function a() {
+                              if (process.env.ZWE_RUN_IN_CONTAINER=="true" && process.env.ZWE_GATEWAY_HOST) {
+                                return ["https://"+process.env.ZWE_GATEWAY_HOST+":"+components.discovery.port+"/eureka/"];
+                              } else if (process.env.ZWE_DISCOVERY_SERVICES_LIST) {
+                                return process.env.ZWE_DISCOVERY_SERVICES_LIST.split(",");
+                              } else {
+                                return ["https://"+zowe.externalDomains[0]+":"+components.discovery.port+"/eureka/"];
+                          a() }}'
           # usually, externalDomains is where gateway is. But on containers, this isnt accessible to containers, so
           # HACK: special var ZWE_GATEWAY_HOST is used instead
           gatewayHostname: '${{ function a() {
@@ -116,6 +125,7 @@ components:
                                 } else {
                                   return zowe.externalDomains[0] } };
                             a() }}'
+          # DEPRECATED. Use discoveryUrls instead.
           port: ${{ components.discovery.port }}
           # strange but true: to contact gateway in a container, dont use the external port.
           gatewayPort: '${{ function a() {

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -115,7 +115,7 @@ components:
                               } else if (process.env.ZWE_DISCOVERY_SERVICES_LIST) {
                                 return process.env.ZWE_DISCOVERY_SERVICES_LIST.split(",");
                               } else {
-                                return ["https://"+zowe.externalDomains[0]+":"+components.discovery.port+"/eureka/"];
+                                return ["https://"+zowe.externalDomains[0]+":"+components.discovery.port+"/eureka/"] } };
                           a() }}'
           # usually, externalDomains is where gateway is. But on containers, this isnt accessible to containers, so
           # HACK: special var ZWE_GATEWAY_HOST is used instead

--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -117,6 +117,14 @@
                   "type": "boolean",
                   "description": "Controls if connections to the API Mediation Layer gateway and/or discovery service should be HTTP or HTTPS"
                 },
+                "discoveryUrls": {
+                  "type": "array",
+                  "description": "A list of URLs where discovery servers can be found. URLs must be in the form of 'https://host:port/eureka/'. This will be used instead of the 'hostname' and 'port' values if present.",
+                  "items": {
+                    "type": "string",
+                    "pattern": "https:\/\/.*:[0-9].*\/eureka\/"
+                  }
+                },
                 "gatewayHostname": {
                   "type": "string",
                   "format": "hostname",
@@ -125,7 +133,8 @@
                 "hostname": {
                   "type": "string",
                   "format": "hostname",
-                  "description": "The hostname or IP where the Zowe Discovery service is running"
+                  "description": "The hostname or IP where the Zowe Discovery service is running",
+                  "deprecated": true
                 },
                 "gatewayPort": {
                   "oneOf": [
@@ -139,6 +148,7 @@
                     { "$ref": "/schemas/v2/server-common#zoweTcpPort" },
                     { "$ref": "/schemas/v2/server-common#zoweReservedTcpPort" }, 
                   ],
+                  "deprecated": true,
                   "description": "The port where the Zowe Discovery service is running"
                 },
                 "enabled": {


### PR DESCRIPTION
The app-server had some behavior where it would sometimes contact the discovery server(s) from the value node.mediationLayer.server.hostname, and other times access from the environment variable ZWE_DISCOVERY_SERVICES_LIST which could contain multiple entries.

It is proper to use a list for discovery whenever possible as the server may need to contact multiple, or failover when one is not found.

Changing the meaning of "hostname" would be a breaking change. Therefore instead I have marked it as deprecated and introduced a new "discoveryUrls" array to clarify that multiple discovery servers may exist.

I have an uncertainty around the container behavior conditional, and will schedule an additional test on it.