### PR TITLE
Remove container-specific discovery url logic

### DIFF
--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -110,9 +110,7 @@ components:
                            return zowe.externalDomains[0] } };
                      a() }}'
           discoveryUrls: '${{ function a() {
-                              if (process.env.ZWE_RUN_IN_CONTAINER=="true" && process.env.ZWE_GATEWAY_HOST) {
-                                return ["https://"+process.env.ZWE_GATEWAY_HOST+":"+components.discovery.port+"/eureka/"];
-                              } else if (process.env.ZWE_DISCOVERY_SERVICES_LIST) {
+                              if (process.env.ZWE_DISCOVERY_SERVICES_LIST) {
                                 return process.env.ZWE_DISCOVERY_SERVICES_LIST.split(",");
                               } else {
                                 return ["https://"+zowe.externalDomains[0]+":"+components.discovery.port+"/eureka/"] } };


### PR DESCRIPTION
In v2.14.0 we revamped discovery url logic to work better for HA/FT
This cleanup removed some hardcoded evaluation of ZWE_DISCOVERY_SERVICES_LIST within the server, so that the server now relies on the zowe.yaml (specifically, defaults.yaml) content only.

In v2.12.0 we discovered weird behavior on containers that worked best when we had the line `if (process.env.ZWE_RUN_IN_CONTAINER=="true" && process.env.ZWE_GATEWAY_HOST) {`
Only, this logic seems to depend upon that old hardcoding of ZWE_DISCOVERY_SERVICES_LIST.
Now that that is removed, container registration is broken.

This PR attempts to fix container registration by removing that conditional so that the registration just does use ZWE_DISCOVERY_SERVICES_LIST as it did before.