### PR TITLE
Allow shell plugins init to be run conditional to user preference

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -54,7 +54,9 @@ cd ../lib
 CONFIG_FILE=$ZWE_CLI_PARAMETER_CONFIG $NODE_BIN initInstance.js
 
 cd ${COMPONENT_HOME}/share/zlux-app-server/bin/init
-if [ "${ZWE_zowe_useConfigmgr}" = "true" ]; then
+if [ "${ZWE_components_app_server_zowe_useConfigmgr}" = "false" ]; then
+  . ./plugins-init.sh  
+elif [ "${ZWE_zowe_useConfigmgr}" = "true" ]; then
   _CEE_RUNOPTS="XPLINK(ON),HEAPPOOLS(OFF)" ${ZWE_zowe_runtimeDirectory}/bin/utils/configmgr -script "${ZWE_zowe_runtimeDirectory}/components/app-server/share/zlux-app-server/bin/init/plugins-init.js"
 else
   . ./plugins-init.sh

--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -6,6 +6,18 @@
   "type": "object",
   "additionalProperties": true,
   "properties": {
+    "zowe": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Contains customizations from the Zowe global configuration.",
+      "properties": {
+        "useConfigmgr": {
+          "type": "boolean",
+          "default": true,
+          "description": "Determines whether configmgr will be used during the startup proceedure, such as to register plugins."
+        }
+      }
+    },
     "node": {
       "type": "object",
       "description": "Configuration options specific to the app-server and things it depends upon",


### PR DESCRIPTION
This adds an option meant for debugging where app-server can use the older shell plugins install process instead of the configmgr one even when zowe.useconfigmgr is set, if desired, by setting components.app-server.zowe.useconfigmgr as an override

This does not introduce new code. Rather, it allows older code to be used upon a condition of configuration.