### PR TITLE
Remove node 14 dns check in start.sh 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 
 ## v2.17.0
 - Enhancement: app-server can now use Zowe's standardized and simplified AT-TLS configuration simply by toggling `zowe.network.server.tls.attls: true` or `components.app-server.zowe.network.server.tls.attls: true`. If you wish to control client tls separately from server tls, you can also use `zowe.network.client.tls.attls` or `components.app-server.zowe.network.client.tls.attls`. (#300)
+- Enhancement: Remove dns check specific to node 14 and below to reduce startup time. Node 14 has not been supported since september 2023. (#304)
 
 ## v2.16.0
 - Bugfix: Removed message saying node not found prior to discovery of node. Now, you will only get an error message if node is not found after lookup in NODE_HOME.

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -95,12 +95,6 @@ if [ "$ZWE_components_app_server_dns_lookupOrder" = "ipv6" ]; then
   ZLUX_DNS_ORDER="--dns-result-order=verbatim"
 fi
 
-# not all versions of node support the above (14.18+ generally) so we can just try it to see what happens.
-v4_check=$(${NODE_BIN} ${ZLUX_DNS_ORDER} -e "console.log('success');")
-if [ "${v4_check}" != "success" ]; then
-  ZLUX_DNS_ORDER=
-fi
-
 if [ -z "${ZWED_FLAGS}" ]; then
   ZWED_FLAGS="${ZLUX_DNS_ORDER} --harmony "
 fi


### PR DESCRIPTION
In node 18, node prefers ipv6 results in dns by default and so we override that with a flag. This flag does not exist on node 14.
So, we had a check by which we'd run node and if it crashed, we'd know the flag wasnt allowed and then not use it.

This is no longer needed because node 14 is no longer supported by zowe.
By removing this check, we save some startup time because we do not need to spawn node just to figure out if it works or not.


Note: you cannot even start with node14 anymore.
This is prevented in the "zwe" startup process by the validation phase of prepare. 
It will say "node ${version} is less than the minimum level required of v${NODE_MIN_VERSION}"