### PR TITLE
Try to detect ssh and telnet port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v2.18.0
+- Enhancement: app-server tries to detect ssh and telnet ports (used by terminals) automatically. (#313)
+
 ## v2.17.0
 - Enhancement: app-server can now use Zowe's standardized and simplified AT-TLS configuration simply by toggling `zowe.network.server.tls.attls: true` or `components.app-server.zowe.network.server.tls.attls: true`. If you wish to control client tls separately from server tls, you can also use `zowe.network.client.tls.attls` or `components.app-server.zowe.network.client.tls.attls`. (#300) (#303)
 - Enhancement: The app-server configure stage performance increased due to combining two seperate processes in this stage (plugins-init.js and initInstance.js) into one. (#304)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
-## v2.18.0
+## v3.0.0
 - Enhancement: app-server tries to detect ssh and telnet ports (used by terminals) automatically. (#313)
 
 ## v2.17.0

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -80,6 +80,39 @@ if [ "$ZWE_zowe_verifyCertificates" = "DISABLED" ]; then
   export NODE_TLS_REJECT_UNAUTHORIZED=0
 fi
 
+# Check ssh and telnet port
+if [ -z "${ZWED_SSH_PORT}" ]; then
+  if [ -e "/etc/ssh/sshd_config" ]; then
+    ssh_port=$(cat "/etc/ssh/sshd_config" | grep '^Port.*' | awk -F\  '{print $2}')
+    # Empty or non-numeric? Set default
+    if [ -z "${ssh_port}" ] || [ -z $(echo "${ssh_port}" | grep -E '^[0-9]{1,5}$') ]; then
+      export ZWED_SSH_PORT=22
+    else
+      # Out of range? Set default
+      if [ "${ssh_port}" -lt 1 ] || [ "${ssh_port}" -gt 65535 ]; then
+        export ZWED_SSH_PORT=22
+      else
+        export ZWED_SSH_PORT="${ssh_port}"
+      fi
+    fi
+  fi
+fi
+
+if [ -z "${ZWED_TN3270_PORT}" ]; then
+  if [ -e "/etc/services" ]; then
+    telnet_port=$(cat "/etc/services" | grep '^telnet' | awk -F\  '{print $2}' | awk -F/ '{print $1}')
+    if [ -z "${telnet_port}" ] || [ -z $(echo "${telnet_port}" | grep -E '^[0-9]{1,5}$') ]; then
+      export ZWED_TN3270_PORT=23
+    else
+      if [ "${telnet_port}" -lt 1 ] || [ "${telnet_port}" -gt 65535 ]; then
+        export ZWED_TN3270_PORT=23
+      else
+        export ZWED_TN3270_PORT="${telnet_port}"
+      fi
+    fi
+  fi
+fi
+
 # set production mode if applicable
 export NODE_ENV=${NODE_ENV:-production}
 

--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -10,11 +10,11 @@
 result=$(type node)
 if [ "$?" -ne "0" ]; then
   if [ -e "${NODE_HOME}/bin/node" ]; then
-    echo "Node found in NODE_HOME"
+    echo "zlux-app-server/bin/validate.sh: Node found in NODE_HOME"
   elif [ -e "${ZOWE_NODE_HOME}/bin/node" ]; then
-    echo "Node found in NODE_HOME"
+    echo "zlux-app-server/bin/validate.sh: Node found in NODE_HOME"
   else 
-    echo "Error: node not found, app-server cannot run"
+    echo "zlux-app-server/bin/validate.sh: Error: Node not found, app-server cannot run"
     exit 1
   fi
 fi

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -2,8 +2,8 @@ zowe:
   workspaceDirectory: ${{ process.env.HOME + '/.zowe/workspace' }}
   externalDomains: ${{ function a() { if (process.env.ZWE_zowe_externalDomains) { return process.env.ZWE_zowe_externalDomains.split(','); } else { return [ os.hostname() ] } }; a() }}
   environments:
-    ZWED_SSH_PORT: 22
-    ZWED_TN3270_PORT: 23
+    ZWED_SSH_PORT: "${{ process.env.ZWED_SSH_PORT ? process.env.ZWED_SSH_PORT : 22 }}"
+    ZWED_TN3270_PORT: "${{ process.env.ZWED_TN3270_PORT ? process.env.ZWED_TN3270_PORT : 23 }}"
     ZWED_TN3270_SECURITY: telnet
     ZWED_SSH_HOST: ${{ zowe.externalDomains[0] }}
     ZWED_TN3270_HOST: ${{ zowe.externalDomains[0] }}

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -28,7 +28,6 @@ commands:
   install: share/zlux-app-server/bin/internal-install.sh
   start: bin/start.sh
   configure: bin/configure.sh
-  validate: bin/validate.sh
 # we do not specify encoding here because its already tagged ascii
 apimlServices:
   dynamic:


### PR DESCRIPTION
## Proposed changes
Try to detect `ssh` and `telnet` port by looking into `/etc/ssh/sshd_config` and `/etc/services`. If such check fails, set the default port `22` and `23` (same as now).

This PR addresses Issue: 
* https://github.com/zowe/zowe-install-packaging/issues/292
  * The PR suggested to add this check into configuration process. I believe it is better to do it during the `app-server` start-up. This approach is independent on the `zowe.yaml` changes: you can set the Zowe not to use `app-server` and later change it.
* https://github.com/zowe/zlux/issues/1022
  * There are 2 confusing messages related to node and as discussed in the issue, this node check is not needed.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
Please delete options that are not relevant.
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

### Small unit test
Test for checking if the logic works as expected:
```
Input='' -> SSH_PORT=22
Input=' ' -> SSH_PORT=22
Input='123 ' -> SSH_PORT=22
Input='0' -> SSH_PORT=22
Input='asdf' -> SSH_PORT=22
Input='99999' -> SSH_PORT=22
Input='file not found' -> SSH_PORT=22
Input='C:\' -> SSH_PORT=22
Input='1' -> SSH_PORT=1
Input='23' -> SSH_PORT=23
Input='144' -> SSH_PORT=144
Input='65535' -> SSH_PORT=65535
```

### Running without variables
In the log:
```
ZWED_SSH_PORT=22
ZWED_TN3270_PORT=23
```

### Running with preset `ZWED_SSH_PORT`
In the log:
```
ZWED_SSH_PORT=123
ZWED_TN3270_PORT=23
```

## Further comments

I keep the setting in `defaults.yaml`. It should work without that, because those variables are exported. But in the future, there might be a way how to do it in JavaScript, keep it as reference. 