### PR TITLE
Read ssh/telnet port from /etc: function and regex update

### DIFF
--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -331,7 +331,8 @@ function readPortFromUnixConfig(configFile, regex) {
         if (matchLine) {
           const portNumber = parseInt(matchLine[0].replace(/\s+/g, " ").split(' ')[1]);
           if (portNumber > 0 && portNumber < 65536) {
-           result = portNumber;
+            printFormattedDebug(`readPortFromUnixConfig: ${configFile} -> "${matchLine[0]}" -> ${portNumber}`);
+            result = portNumber;
           }
         }
       }

--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -322,7 +322,7 @@ module.exports.registerBundledPlugin = registerBundledPlugin;
 
 function readPortFromUnixConfig(configFile, regex) {
   let result = 0;
-  if (fs.fileExists(configFile)) {
+  if (fileExists(configFile)) {
     const configContent = fs.readFileSync(configFile, 'utf8');
     if (configContent) {
       const configLines = configContent.split('\n');
@@ -343,7 +343,7 @@ function readPortFromUnixConfig(configFile, regex) {
 module.exports.setTerminalDefaults = function(configDestination, instanceItems) {
   if (instanceItems.indexOf('org.zowe.terminal.vt.json') != -1) {
     if (!process.env['ZWED_SSH_PORT']) {
-      const sshPort = readPortFromUnixConfig('/etc/ssh/sshd_config', /port[\s]+[0-9]{1,5}/i);
+      const sshPort = readPortFromUnixConfig('/etc/ssh/sshd_config', /^port[\s]+[0-9]{1,5}/i);
       if (sshPort) {
         process.env['ZWED_SSH_PORT'] = sshPort;
       }
@@ -361,7 +361,7 @@ module.exports.setTerminalDefaults = function(configDestination, instanceItems) 
   }
   if (instanceItems.indexOf('org.zowe.terminal.tn3270.json') != -1) {
     if (!process.env['ZWED_TN3270_PORT']) {
-      const telnetPort = readPortFromUnixConfig('/etc/services', /telnet[\s]+[0-9]{1,5}/i);
+      const telnetPort = readPortFromUnixConfig('/etc/services', /^telnet[\s]+[0-9]{1,5}/i);
       if (telnetPort) {
         process.env['ZWED_TN3270_PORT'] = telnetPort;
       }


### PR DESCRIPTION
Update of untested #326:
* `fs.fileExists` should be without `fs`
* Regex is missing start (`^`), it was returning port of `otelnet` on our system

With the debug mode
```
2024-11-07 11:12:07.193 <ZWED:33949259> ZWESVUSR DEBUG (plugins-init) readPortFromUnixConfig: /etc/ssh/sshd_config -> "Port 123" -> 123
2024-11-07 11:12:07.198 <ZWED:33949259> ZWESVUSR DEBUG (plugins-init) readPortFromUnixConfig: /etc/services -> "telnet          345" -> 345
```