### PR TITLE
Add cookieName config for apiml

### DIFF
--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -146,6 +146,7 @@ components:
                            return zowe.externalPort } };
                      a() }}'
           isHttps: true
+          cookieName: "${{ components.gateway?.apiml?.security?.auth?.uniqueCookie && zowe.cookieIdentifier ? 'apimlAuthenticationToken.' + zowe.cookieIdentifier : 'apimlAuthenticationToken' }}"
           cachingService:
             enabled: ${{ components['app-server'].node.mediationLayer.enabled && components['caching-service'].enabled }}
         enabled: ${{ components.gateway.enabled && components.discovery.enabled }}

--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -167,6 +167,11 @@
                   "type": "boolean",
                   "description": "Controls whether the app-server should register to the Zowe API Mediation Layer as a Eureka Client"
                 },
+                "cookieName": {
+                  "type": "string",
+                  "description": "Informs app-server of the gateway's cookie name needed for SSO",
+                  "default": "apimlAuthenticationToken"
+                },
                 "cachingService": {
                   "type": "object",
                   "additionalProperties": false,


### PR DESCRIPTION
This PR adds a property into defaults.yaml and schema where app-server will learn of gateway's cookie name as described within https://github.com/zowe/docs-site/pull/3977

It is needed for PR https://github.com/zowe/zlux-server-framework/pull/573