### PR TITLE
Add pkcs12 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
-- Enhancement: Support PKCS12 and default to loading PKCS12 files instead of PEM when keystore or truststore type is PKCS12. (#???)[https://github.com/zowe/pulls/???]
+
+- Enhancement: Support PKCS12 and default to loading PKCS12 files instead of PEM when keystore or truststore type is PKCS12. (#337)[https://github.com/zowe/pulls/337]
 
 ## v3.5.0
 - Enhancement: App-server startup no longer runs certificate validation as that has been migrated to the zwe launcher startup process to work for all components. [(#364)](https://github.com/zowe/zlux-app-server/pull/364)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
-
-- Enhancement: Support PKCS12 and default to loading PKCS12 files instead of PEM when keystore or truststore type is PKCS12. (#337)[https://github.com/zowe/pulls/337]
+- Enhancement: Support PKCS12 and default to loading PKCS12 files instead of PEM when keystore or truststore type is PKCS12. [(#337)](https://github.com/zowe/pulls/337)
 
 ## v3.5.0
 - Enhancement: App-server startup no longer runs certificate validation as that has been migrated to the zwe launcher startup process to work for all components. [(#364)](https://github.com/zowe/zlux-app-server/pull/364)
@@ -21,7 +20,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 - Enhancement: app-server handles the setting "components.apiml.enabled: true" as an alternative to enabling "gateway", "discovery", and "caching-service" components. [(#345)](https://github.com/zowe/zlux-app-server/pull/345)
 
 ## v3.2.0
-- Bugfix: Configuration property "components.app-server.node.mediationLayer.eureka" was not documented in the schema, so it was not possible to set in configuration (#336)
+- Bugfix: Configuration property "components.app-server.node.mediationLayer.eureka" was not documented in the schema, so it was not possible to set in configuration [(#336)](https://github.com/zowe/pulls/336)
 - Enhancement: Validate certificate properties on startup. [(#338)](https://github.com/zowe/zlux-app-server/pull/338)
 
 ## v3.1.0
@@ -37,7 +36,6 @@ All notable changes to the Zlux App Server package will be documented in this fi
 - Enhancement: app-server can now use Zowe's standardized and simplified AT-TLS configuration simply by toggling `zowe.network.server.tls.attls: true` or `components.app-server.zowe.network.server.tls.attls: true`. If you wish to control client tls separately from server tls, you can also use `zowe.network.client.tls.attls` or `components.app-server.zowe.network.client.tls.attls`. (#300) (#303)
 - Enhancement: The app-server configure stage performance increased due to combining two separate processes in this stage (plugins-init.js and initInstance.js) into one. (#304)
 - Enhancement: Remove dns check specific to node 14 and below to reduce startup time. Node 14 has not been supported since September 2023. (#304)
-
 
 ## v2.16.0
 - Bugfix: Removed message saying node not found prior to discovery of node. Now, you will only get an error message if node is not found after lookup in NODE_HOME.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v3.6.0
 - Enhancement: Support PKCS12 and default to loading PKCS12 files instead of PEM when keystore or truststore type is PKCS12. [(#337)](https://github.com/zowe/pulls/337)
 
 ## v3.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+- Enhancement: Support PKCS12 and default to loading PKCS12 files instead of PEM when keystore or truststore type is PKCS12. (#???)[https://github.com/zowe/pulls/???]
+
 ## v3.5.0
 - Enhancement: App-server startup no longer runs certificate validation as that has been migrated to the zwe launcher startup process to work for all components. [(#364)](https://github.com/zowe/zlux-app-server/pull/364)
 - Enhancement: App-server now supports separate server and client TLS certificates. Define `zowe.certificate.keystore.clientCertificateAlias` (for keyrings) or `zowe.certificate.pem.clientCertificate` and `zowe.certificate.pem.clientKey` (for PEM files) to use a dedicated client certificate for all outbound connections. The main certificate continues to be used for serving HTTPS. When not defined, the existing certificate is used for both as before. [(#365)](https://github.com/zowe/zlux-app-server/pull/365) [(#364)](https://github.com/zowe/zlux-app-server/pull/364)
@@ -34,6 +36,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 - Enhancement: app-server can now use Zowe's standardized and simplified AT-TLS configuration simply by toggling `zowe.network.server.tls.attls: true` or `components.app-server.zowe.network.server.tls.attls: true`. If you wish to control client tls separately from server tls, you can also use `zowe.network.client.tls.attls` or `components.app-server.zowe.network.client.tls.attls`. (#300) (#303)
 - Enhancement: The app-server configure stage performance increased due to combining two separate processes in this stage (plugins-init.js and initInstance.js) into one. (#304)
 - Enhancement: Remove dns check specific to node 14 and below to reduce startup time. Node 14 has not been supported since September 2023. (#304)
+
 
 ## v2.16.0
 - Bugfix: Removed message saying node not found prior to discovery of node. Now, you will only get an error message if node is not found after lookup in NODE_HOME.

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -61,6 +61,8 @@ components:
         keys: '${{ function a() {
                      if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")) {
                        return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.alias ];
+                     } else if (zowe.certificate.keystore?.file) {
+                       return [ zowe.certificate.keystore.file ];
                      } else if (zowe.certificate?.pem?.key) {
                        return [ zowe.certificate.pem.key ];
                      } else {
@@ -69,6 +71,8 @@ components:
         certificates: '${{ function a(){
                              if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")) {
                                return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.alias ];
+                             } else if (zowe.certificate.keystore?.file) {
+                               return [ zowe.certificate.keystore.file ];
                              } else if (zowe.certificate?.pem?.certificate) {
                                return [ zowe.certificate.pem.certificate ];
                              } else {
@@ -93,7 +97,7 @@ components:
                                      return undefined; } };
                               a() }}'
         certificateAuthorities: '${{ function a() {
-                                       if (zowe.certificate?.truststore?.type && zowe.certificate.truststore.type.match("JCE.*KS")) {
+                                       if (zowe.certificate?.truststore?.file) {
                                           return [ zowe.certificate.truststore.file ];
                                        } else if(zowe.certificate?.pem?.certificateAuthorities) {
                                           if (Array.isArray(zowe.certificate.pem.certificateAuthorities)) {

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -61,17 +61,18 @@ components:
         keys: '${{ function a() {
                      if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")) {
                        return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.alias ];
-                     } else if (zowe.certificate.keystore?.file) {
+                     } else if (zowe.certificate.keystore?.file && !components["app-server"]?.node?.https?.preferPem) {
                        return [ zowe.certificate.keystore.file ];
                      } else if (zowe.certificate?.pem?.key) {
                        return [ zowe.certificate.pem.key ];
                      } else {
                        return [ "../defaults/serverConfig/zlux.keystore.key" ]; } };
                 a() }}'
+        preferPem: false
         certificates: '${{ function a(){
                              if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")) {
                                return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.alias ];
-                             } else if (zowe.certificate.keystore?.file) {
+                             } else if (zowe.certificate.keystore?.file && !components["app-server"]?.node?.https?.preferPem) {
                                return [ zowe.certificate.keystore.file ];
                              } else if (zowe.certificate?.pem?.certificate) {
                                return [ zowe.certificate.pem.certificate ];
@@ -82,7 +83,7 @@ components:
                            if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")
                                && zowe.certificate?.keystore?.clientCertificateAlias) {
                              return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.clientCertificateAlias ];
-                           } else if (zowe.certificate.keystore?.file && zowe.certificate.keystore?.clientCertificateAlias) {
+                           } else if (zowe.certificate.keystore?.file && zowe.certificate.keystore?.clientCertificateAlias && !components["app-server"]?.node?.https?.preferPem ) {
                              return [ zowe.certificate.keystore.file ];
                            } else if (zowe.certificate?.pem?.clientKey) {
                              return [ zowe.certificate.pem.clientKey ];
@@ -93,7 +94,7 @@ components:
                                    if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")
                                        && zowe.certificate?.keystore?.clientCertificateAlias) {
                                      return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.clientCertificateAlias ];
-                                   } else if (zowe.certificate.keystore?.file && zowe.certificate.keystore?.clientCertificateAlias) {
+                                   } else if (zowe.certificate.keystore?.file && zowe.certificate.keystore?.clientCertificateAlias && !components["app-server"]?.node?.https?.preferPem) {
                                      return [ zowe.certificate.keystore.file ];
                                    } else if (zowe.certificate?.pem?.clientCertificate) {
                                      return [ zowe.certificate.pem.clientCertificate ];
@@ -101,7 +102,7 @@ components:
                                      return undefined; } };
                               a() }}'
         certificateAuthorities: '${{ function a() {
-                                       if (zowe.certificate?.truststore?.file) {
+                                       if (zowe.certificate?.truststore?.file && !components["app-server"]?.node?.https?.preferPem) {
                                           return [ zowe.certificate.truststore.file ];
                                        } else if(zowe.certificate?.pem?.certificateAuthorities) {
                                           if (Array.isArray(zowe.certificate.pem.certificateAuthorities)) {

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -82,6 +82,8 @@ components:
                            if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")
                                && zowe.certificate?.keystore?.clientCertificateAlias) {
                              return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.clientCertificateAlias ];
+                           } else if (zowe.certificate.keystore?.file && zowe.certificate.keystore?.clientCertificateAlias) {
+                             return [ zowe.certificate.keystore.file ];
                            } else if (zowe.certificate?.pem?.clientKey) {
                              return [ zowe.certificate.pem.clientKey ];
                            } else {
@@ -91,6 +93,8 @@ components:
                                    if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")
                                        && zowe.certificate?.keystore?.clientCertificateAlias) {
                                      return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.clientCertificateAlias ];
+                                   } else if (zowe.certificate.keystore?.file && zowe.certificate.keystore?.clientCertificateAlias) {
+                                     return [ zowe.certificate.keystore.file ];
                                    } else if (zowe.certificate?.pem?.clientCertificate) {
                                      return [ zowe.certificate.pem.clientCertificate ];
                                    } else {

--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -59,6 +59,12 @@
             "certificateRevocationLists": {
               "$ref": "#/$defs/certObject"
             },
+            "preferPem": {
+              "type": "boolean",
+              "default": false,
+              "deprecated": true,
+              "description": "Discouraged. Used for old behavior where PEM is read instead of PKCS12."
+            },
             "secureOptions": {
               "type": "integer",
               "description": "Controls nodejs' use of OpenSSL via integers composed of the values in the references https://github.com/openssl/openssl/blob/master/include/openssl/ssl.h.in and https://nodejs.org/api/crypto.html#openssl-options"


### PR DESCRIPTION
Depends upon https://github.com/zowe/zlux-server-framework/pull/596

This PR allows app-server to use PKCS12 instead of PEM files when you aren't using SAF keyrings.
