### PR TITLE
Validate certificates on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 - Enhancement: app-server can now use Zowe's standardized and simplified AT-TLS configuration simply by toggling `zowe.network.server.tls.attls: true` or `components.app-server.zowe.network.server.tls.attls: true`. If you wish to control client tls separately from server tls, you can also use `zowe.network.client.tls.attls` or `components.app-server.zowe.network.client.tls.attls`. (#300) (#303)
 - Enhancement: The app-server configure stage performance increased due to combining two seperate processes in this stage (plugins-init.js and initInstance.js) into one. (#304)
 - Enhancement: Remove dns check specific to node 14 and below to reduce startup time. Node 14 has not been supported since september 2023. (#304)
+- Enhancement: Validate certificate properties on startup. (???)
 
 ## v2.16.0
 - Bugfix: Removed message saying node not found prior to discovery of node. Now, you will only get an error message if node is not found after lookup in NODE_HOME.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ All notable changes to the Zlux App Server package will be documented in this fi
 - Enhancement: The app-server configure stage performance increased due to combining two seperate processes in this stage (plugins-init.js and initInstance.js) into one. (#304)
 - Enhancement: Remove dns check specific to node 14 and below to reduce startup time. Node 14 has not been supported since september 2023. (#304)
 
-
 ## v2.16.0
 - Bugfix: Removed message saying node not found prior to discovery of node. Now, you will only get an error message if node is not found after lookup in NODE_HOME.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 
 ## v3.2.0
 - Bugfix: Configuration property "components.app-server.node.mediationLayer.eureka" was not documented in the schema, so it was not possible to set in configuration (#336)
+- Enhancement: Validate certificate properties on startup. [(#338)](https://github.com/zowe/zlux-app-server/pull/338)
 
 ## v3.1.0
 - Enhancement: if no `zowe.logDirectory` is defined in config, logging is disabled. [(#317)](https://github.com/zowe/zlux-app-server/pull/317)
@@ -18,7 +19,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 - Enhancement: app-server can now use Zowe's standardized and simplified AT-TLS configuration simply by toggling `zowe.network.server.tls.attls: true` or `components.app-server.zowe.network.server.tls.attls: true`. If you wish to control client tls separately from server tls, you can also use `zowe.network.client.tls.attls` or `components.app-server.zowe.network.client.tls.attls`. (#300) (#303)
 - Enhancement: The app-server configure stage performance increased due to combining two seperate processes in this stage (plugins-init.js and initInstance.js) into one. (#304)
 - Enhancement: Remove dns check specific to node 14 and below to reduce startup time. Node 14 has not been supported since september 2023. (#304)
-- Enhancement: Validate certificate properties on startup. (???)
+
 
 ## v2.16.0
 - Bugfix: Removed message saying node not found prior to discovery of node. Now, you will only get an error message if node is not found after lookup in NODE_HOME.

--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# This program and the accompanying materials are
+# made available under the terms of the Eclipse Public License v2.0 which accompanies
+# this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+# 
+# SPDX-License-Identifier: EPL-2.0
+# 
+# Copyright Contributors to the Zowe Project.
+
+if [ "${ZWE_RUN_ON_ZOS}" = "true" ]; then
+  if [ "${ZWED_SKIP_VALIDATE_CERT}" = "true"]; then
+    exit 0
+  else
+    cert_type=$ZWE_zowe_certificate_keystore_type
+    cert_file=$ZWE_zowe_certificate_keystore_file
+    cert_alias=$ZWE_zowe_certificate_keystore_alias
+    eku=
+
+    if [ "${ZWE_components_gateway_enabled}" = "true" ]; then
+      eku=" -e"  
+    elif [ "${ZWE_components_discovery_enabled}" = "true" ]; then
+      eku=" -e"
+    fi
+
+    COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/app-server
+
+    cd ${COMPONENT_HOME}/share/zlux-app-server/bin
+    . ./init/node-init.sh
+    cd ${COMPONENT_HOME}/share/zlux-server-framework/utils
+    $NODE_BIN certificateChecker -c "${cert_file}" -t "${cert_type}" -a "${cert_alias}"${eku}
+  fi
+fi

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -25,6 +25,7 @@ build:
   commitHash: "{{build.commitHash}}"
   timestamp: {{build.timestamp}}
 commands:
+  validate: bin/validate.sh
   install: share/zlux-app-server/bin/internal-install.sh
   start: bin/start.sh
   configure: bin/configure.sh


### PR DESCRIPTION
Depends upon https://github.com/zowe/zlux-server-framework/pull/597

This PR runs the zlux utility certChecker.js which allows app-server to detect whether or not Zowe has certificates that are going to succeed at runtime.
This check only runs on zOS, to avoid any dev or container issues.

You can test this by using certificates that are valid for zowe, versus certificates that are not.
For example, try an expired certificate.
Or try a certificate without an EKU.
This code will reject startup when these invalid states are seen.

This code should also not cause disruption when certificates are valid. No currently working zowe installs should be disrupted by this check.

You should also see that the check prints out WHEN a certificate expires, which helps you confirm that the certificate was indeed checked!

Finally, if anything goes wrong, you can disable this check with env var `ZWED_SKIP_VALIDATE_CERT=true`