### PR TITLE
Fix syntax error of validate.sh

### DIFF
--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -8,7 +8,7 @@
 # Copyright Contributors to the Zowe Project.
 
 if [ "${ZWE_RUN_ON_ZOS}" = "true" ]; then
-  if [ "${ZWED_SKIP_VALIDATE_CERT}" = "true"]; then
+  if [ "${ZWED_SKIP_VALIDATE_CERT}" = "true" ]; then
     exit 0
   else
     cert_type=$ZWE_zowe_certificate_keystore_type


### PR DESCRIPTION
During testing, it was found that though the validate was doing the correct default behavior, it was at least printing that line 11 had a syntax error, and it did - it was missing a single space " ".
Fixed this and the error is gone.