### PR TITLE
include ipc mq cleanup within start.sh

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -61,26 +61,19 @@ cd ${ZLUX_APP_SERVER_DIR}/bin
 if [ "${ZWE_RUN_ON_ZOS}" = "true" ]; then  
   id=$(id -nu)
   # Trying to capture columns T, ID, and second to last column, which for q=LSPID, m=CPID
-  for s in $(ipcs -a | awk 'match($1,"q|m") && $5 == "'${id}'" {print $1","$2":"$(NF-1)}'); do
-    x=${s%%:*}
-    pid=${s##*:}
-    type=${x%%,*}
-    num=${x##*,}
+  for s in $(ipcs -a | awk 'match($1,"q|m") && $5 == "'${id}'" { print "type=\""$1"\";pid=\""$2"\";num=\""$(NF-1)"\"" }'); do
+    eval "${s}"
     if [[ $pid -gt 0 ]]; then
       kill -0 "$pid" 1>/dev/null 2>&1
-      if [ $? -eq 0 ]; then
-        true
-      else
+      if [ $? -ne 0 ]; then
         ipcrm -$type $num
       fi
     fi
   done
-  
+
   # Trying to capture columns T, ID. Type=S has no PID to capture
-  for s in $(ipcs -a | awk 'match($1,"s") && $5 == "'${id}'" {print $1","$2}'); do
-    type=${s%%,*}
-    num=${s##*,}
-    ipcrm -$type $num
+  for s in $(ipcs -a | awk 'match($1,"s") && $5 == "'${id}'" { print $2 }'); do
+    ipcrm -s $s
   done
 fi
 ###################################

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -40,6 +40,53 @@ cd ${ZLUX_APP_SERVER_DIR}/bin
 . ./init/node-init.sh
 . ./utils/setup-logs.sh
 
+
+###################################
+# Start cleanup of node IPC MQ
+###################################
+# node.js instance is not fully cleaned up when exits. As time going, the message
+# queue will be full and any node.js command will generate this error:
+#
+# msgget: EDC5133I No space left on device. (errno2=0x07050305)
+# CEE5207E The signal SIGABRT was received.
+# Ended with rc=131
+#
+# FIXME: this is a temporary workaround suggested by node.js team.
+# export __IPC_CLEANUP=1
+#
+# Always export __IPC_CLEANUP=1 caused another problem which the node.js process
+# may randomly hang on __getipc().
+#
+# This is proper way to cleanup IPC message queues.
+if [ "${ZWE_RUN_ON_ZOS}" = "true" ]; then  
+  id=$(id -nu)
+  # Trying to capture columns T, ID, and second to last column, which for q=LSPID, m=CPID
+  for s in $(ipcs -a | awk 'match($1,"q|m") && $5 == "'${id}'" {print $1","$2":"$(NF-1)}'); do
+    x=${s%%:*}
+    pid=${s##*:}
+    type=${x%%,*}
+    num=${x##*,}
+    if [[ $pid -gt 0 ]]; then
+      kill -0 "$pid" 1>/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        true
+      else
+        ipcrm -$type $num
+      fi
+    fi
+  done
+  
+  # Trying to capture columns T, ID. Type=S has no PID to capture
+  for s in $(ipcs -a | awk 'match($1,"s") && $5 == "'${id}'" {print $1","$2}'); do
+    type=${s%%,*}
+    num=${s##*,}
+    ipcrm -$type $num
+  done
+fi
+###################################
+# End cleanup of node IPC MQ
+###################################
+
 # Get config path or fail
 if [ -z "${ZWE_CLI_PARAMETER_CONFIG}" ]; then
   echo "ZWE_CLI_PARAMETER_CONFIG is not defined. Only defaults will be used."


### PR DESCRIPTION
Code to clean IPC MQ for the benefit of running nodejs code on z/os (particularly I believe code that uses nodejs clustering) was included in the zwe codebase.

I believe this code is only for the benefit of the app-server, and so, moving it into the app-server code would be less confusing to people trying to learn the meaning of it, and less of a burden on the other codebases.