### PR TITLE
Accomodate components.apiml.enabled=true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
-## v3.3.3
-- Enhancement: app-server handles the setting "components.apiml.enabled: true" as an alternative to enabling "gateway", "discovery", and "caching-service" components.
+## v3.3.0
+- Enhancement: app-server handles the setting "components.apiml.enabled: true" as an alternative to enabling "gateway", "discovery", and "caching-service" components. [(#345)](https://github.com/zowe/zlux-app-server/pull/345)
 
 ## v3.2.0
 - Bugfix: Configuration property "components.app-server.node.mediationLayer.eureka" was not documented in the schema, so it was not possible to set in configuration (#336)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v3.3.3
+- Enhancement: app-server handles the setting "components.apiml.enabled: true" as an alternative to enabling "gateway", "discovery", and "caching-service" components.
+
 ## v3.2.0
 - Bugfix: Configuration property "components.app-server.node.mediationLayer.eureka" was not documented in the schema, so it was not possible to set in configuration (#336)
 - Enhancement: Validate certificate properties on startup. [(#338)](https://github.com/zowe/zlux-app-server/pull/338)

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -23,7 +23,14 @@ fi
 
 cd ${COMPONENT_HOME}/share/zlux-app-server/bin
 
+apiml_enabled=false
 if [ "$ZWE_components_gateway_enabled" = "true" ]; then
+  apiml_enabled=true
+elif [ "$ZWE_components_apiml_enabled" = "true" ]; then
+  apiml_enabled=true
+fi
+
+if [ "$apiml_enabled" = "true" ]; then
   if [ "$ZWE_components_zss_enabled" = "true" ]; then
     if [ "${ZWE_RUN_ON_ZOS}" != "true" ]; then
       zss_def_template="zss.apiml_static_reg.yaml.template"

--- a/bin/validate.sh
+++ b/bin/validate.sh
@@ -19,7 +19,9 @@ if [ "${ZWE_RUN_ON_ZOS}" = "true" ]; then
     if [ "${ZWE_components_gateway_enabled}" = "true" ]; then
       eku=" -e"  
     elif [ "${ZWE_components_discovery_enabled}" = "true" ]; then
-      eku=" -e"
+        eku=" -e"
+    elif [ "${ZWE_components_apiml_enabled}" = "true" ]; then
+        eku=" -e"
     fi
 
     COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/app-server

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -147,8 +147,8 @@ components:
                      a() }}'
           isHttps: true
           cachingService:
-            enabled: ${{ components['app-server'].node.mediationLayer.enabled && components['caching-service'].enabled }}
-        enabled: ${{ components.gateway.enabled && components.discovery.enabled }}
+            enabled: ${{ components['app-server'].node.mediationLayer.enabled && (components.apiml?.enabled || components['caching-service']?.enabled) }}
+        enabled: ${{ components.apiml?.enabled || (components.gateway?.enabled && components.discovery?.enabled) }}
       headers:
         X-frame-Options:
           override: true
@@ -173,7 +173,7 @@ components:
     pluginsDir: ${{ components['app-server'].instanceDir }}/plugins
     dataserviceAuthentication:
       # this specifies the default authentication type for dataservices that didn't specify which type to use. These dataservices therefore should not expect a particular type of authentication to be used.
-      defaultAuthentication: "${{ function a(){ if ((components.zss?.enabled == true) || (components.gateway?.enabled == true)) { return 'saf'; } else { return 'fallback'; } }; a() }}"
+      defaultAuthentication: "${{ function a(){ if ((components.zss?.enabled == true) || (components.apiml?.enabled == true) || (components.gateway?.enabled == true)) { return 'saf'; } else { return 'fallback'; } }; a() }}"
       rbac: false
     instanceID: ${{ zowe.rbacProfileIdentifier }}
     cookieIdentifier: ${{ zowe.cookieIdentifier }}


### PR DESCRIPTION
This PR checks all variables that used to check for discovery/gateway/caching-service and allows components.apiml.enabled to be a substitute for them.