### PR TITLE
Ability to disable bundled apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v3.4.0
+- Enhancement: Built-in apps such as 'zlux-editor', 'tn3270-ng2', 'vt-ng2' can now be enabled or disabled using the Zowe YAML with the same syntax as seen in other apps such as 'explorer-jes'. [(#?)]()
+
 ## v3.3.0
 - Enhancement: app-server handles the setting "components.apiml.enabled: true" as an alternative to enabling "gateway", "discovery", and "caching-service" components. [(#345)](https://github.com/zowe/zlux-app-server/pull/345)
 

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -225,6 +225,10 @@ function getEnabledEmbeddedComponents(embeddedComponents) {
     if (explicitlyDisabled) {
       return false;
     }
+    const explicitlyEnabled = process.env['ZWE_components_'+component_to_yaml_name+'_enabled'] == 'true';
+    if (explicitlyEnabled) {
+      return true;
+    }
     return COMPONENTS_TO_ENABLE_BY_DEFAULT.includes(component);
   });
 }

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -199,14 +199,61 @@ if (siteStorage.length == 0 && instanceStorage.length == 0) {
 //   //skip process
 // }
 
+const COMPONENTS_TO_ENABLE_BY_DEFAULT = [
+  'tn3270-ng2',
+  'vt-ng2',
+  'explorer-ip',
+  'zlux-editor'
+];
+
+
 const RUNTIME_DIRECTORY=process.env.ZWE_zowe_runtimeDirectory;
 const EXTENSION_DIRECTORY=process.env.ZWE_zowe_extensionDirectory;
 
 const INSTALLED_COMPONENTS_ENV=process.env.ZWE_INSTALLED_COMPONENTS;
-const INSTALLED_COMPONENTS = INSTALLED_COMPONENTS_ENV ? INSTALLED_COMPONENTS_ENV.split(',') : [];
+const EMBEDDED_COMPONENTS = getEmbeddedComponents();
+const INSTALLED_COMPONENTS = (INSTALLED_COMPONENTS_ENV ? INSTALLED_COMPONENTS_ENV.split(',') : []).concat(EMBEDDED_COMPONENTS);
 
 const ENABLED_COMPONENTS_ENV=process.env.ZWE_ENABLED_COMPONENTS;
-const ENABLED_COMPONENTS = ENABLED_COMPONENTS_ENV ? ENABLED_COMPONENTS_ENV.split(',') : [];
+const ENABLED_COMPONENTS = (ENABLED_COMPONENTS_ENV ? ENABLED_COMPONENTS_ENV.split(',') : []).concat(getEnabledEmbeddedComponents(EMBEDDED_COMPONENTS));
+
+
+function getEnabledEmbeddedComponents(embeddedComponents) {
+  return embeddedComponents.filter((component) => {
+    const component_to_yaml_name = component.replaceAll('-', '_');
+    const explicitlyDisabled = process.env['ZWE_components_'+component_to_yaml_name+'_enabled'] == 'false';
+    if (explicitlyDisabled) {
+      return false;
+    }
+    return COMPONENTS_TO_ENABLE_BY_DEFAULT.includes(component);
+  });
+}
+
+function getEmbeddedComponents() {
+  let embeddedComponents = [];
+  if (RUNTIME_DIRECTORY) {
+    const shareDir = RUNTIME_DIRECTORY+'/components/app-server/share';
+    if (initUtils.directoryExists(shareDir)) {
+      fs.readdirSync(shareDir, {withFileTypes: true}).filter(statObj=> !statObj.isFile())
+        .forEach((statObj) => {
+          const folderName = statObj.name;
+          const folderPath = path.resolve(shareDir, folderName);
+          if (initUtils.getManifestPath(folderPath)) {
+            embeddedComponents.push(folderName);
+          }
+        });
+      fs.readdirSync(shareDir+'/zlux-app-manager/system-apps', {withFileTypes: true}).filter(statObj=> !statObj.isFile())
+        .forEach((statObj) => {
+          const folderName = statObj.name;
+          const folderPath = path.resolve(shareDir+'/zlux-app-manager/system-apps', folderName);
+          if (initUtils.getManifestPath(folderPath)) {
+            embeddedComponents.push(folderName);
+          }
+        });
+    }
+  }
+  return embeddedComponents;
+}
 
 
 initUtils.printFormattedDebug("Start component iteration");

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -217,7 +217,9 @@ INSTALLED_COMPONENTS.forEach(function(installedComponent) {
     const enabled = ENABLED_COMPONENTS.includes(installedComponent);
     initUtils.printFormattedDebug(`Checking plugins for component=${installedComponent}, enabled=${enabled}`);
 
-    const manifest = YAML.parse(fs.readFileSync(initUtils.getManifestPath(componentDirectory), 'utf8'));
+    const manifestLocation = initUtils.getManifestPath(componentDirectory);
+    const rawManifest = fs.readFileSync(manifestLocation, 'utf8');
+    const manifest = manifestLocation.endsWith('.json') ? JSON.parse(rawManifest) : YAML.parse(rawManifest);
     if (manifest.appfwPlugins) {
       manifest.appfwPlugins.forEach(function (manifestPluginRef) {
         const path = manifestPluginRef.path;

--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -106,7 +106,7 @@ function directoryExists(directory) {
     return false;
   }
 }
-module.exports.directoryExits = directoryExists;
+module.exports.directoryExists = directoryExists;
 
 function fileExists(file) {
   try {

--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -74,7 +74,7 @@ function getManifestPath(componentDir) {
     return `${componentDir}/manifest.yaml`;
   } else if (fileExists(`${componentDir}/manifest.yml`)) {
     return `${componentDir}/manifest.yml`;
-  } else if (fileExists(`${componentDir}/manifest.yaml`)) {
+  } else if (fileExists(`${componentDir}/manifest.json`)) {
     return `${componentDir}/manifest.json`;
   }
   return undefined;
@@ -86,6 +86,8 @@ function findComponentDirectory(runtimeDirectory, extensionDirectory, componentI
     return `${runtimeDirectory}/components/${componentId}`;
   } else if (extensionDirectory && directoryExists(`${extensionDirectory}/${componentId}`)) {
     return `${extensionDirectory}/${componentId}`;
+  } else if (directoryExists(`${runtimeDirectory}/components/app-server/share/${componentId}`)) {
+    return `${runtimeDirectory}/components/app-server/share/${componentId}`;
   }
   return undefined;
 }


### PR DESCRIPTION
This enhancement allows you to put the following in your YAML

```yaml
components:
  tn3270-ng2:
    enabled: false
```

If you did that prior, nothing much would happen. No errors, but no benefit.
Now, this is respected.

The logic is a bit silly:

1) startup checks if the /plugins folder needs to be reset and add back all bundled and core plugins based on if core plugins are there
2) extensions and non-bundled plugins are added or removed from /plugins folder depending upon "enabled" status of yaml
3) NEW - bundled plugins are REMOVED if the YAML has them marked disabled

So, 1) adds them blindly, and 3) removes them conditionally. Kind of silly but I did not want to cause any backward compatibility issues or update the "defaults" folder.

Defaults are unchanged. This just allows you to customize which plugins are available.

In this PR I also spotted a bug about manifest.json not being handled.
I have never seen a manifest.json. They have always been manifest.yaml
But during v2.0 development, we said it would be possible and so this code was written but untested I guess.