### PR TITLE
Prevent sysMessages from being in ZWED5018I message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 
 ## v3.4.0
 - Enhancement: Added new flag in zowe.yaml 'enablePasswordChange' which controls the access to 'Change Password' tool in 'Personalization Panel'.
+- Bugfix: App-server no longer prints out the contents of "zowe.sysMessages", so that it will not get captured by the syslog messaging system of the launcher. [(#352)](https://github.com/zowe/zlux-app-server/pull/352)
 
 ## v3.3.0
 - Enhancement: app-server handles the setting "components.apiml.enabled: true" as an alternative to enabling "gateway", "discovery", and "caching-service" components. [(#345)](https://github.com/zowe/zlux-app-server/pull/345)

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -79,7 +79,12 @@ if(configJSON.components['app-server'].node.noChild === true){
 }
 
 if (cluster.isMaster) {
-  console.log('\nZWED5018I - Initializing with configuration:\n',JSON.stringify(configJSON, null, 2));
+  let configJSONSafeToPrint = Object.assign({}, configJSON);
+  if (configJSONSafeToPrint.zowe.sysMessages) {
+    delete configJSONSafeToPrint.zowe.sysMessages;
+  }
+
+  console.log('\nZWED5018I - Initializing with configuration:\n',JSON.stringify(configJSONSafeToPrint, null, 2));
 }
 module.exports = function() {
   return {configJSON: configJSON, configLocation: userInput.config}


### PR DESCRIPTION
Fixes https://github.com/zowe/launcher/issues/131
This is an weird case - this server prints out the sysMessages array that launcher uses to determine which lines to print to the syslog. By changing this server to just not print that array, the issue should be resolved.