### PR TITLE
Prevent sysMessages from being in ZWED5018I message (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v2.18.4
+- Bugfix: App-server no longer prints out the contents of "zowe.sysMessages", so that it will not get captured by the syslog messaging system of the launcher. [(#353)](https://github.com/zowe/zlux-app-server/pull/353)
+
 ## v2.18.1
 - Bugfix: app-server no longer causes Zowe to print "FSUM7422 node is not found" and "Node found in NODE_HOME" upon startup. This avoids confusion about if node requirements are met. (#324)
 - Bugfix: Configuration property "components.app-server.node.mediationLayer.eureka" was not documented in the schema, so it was not possible to set in configuration (#334)

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -79,7 +79,12 @@ if(configJSON.components['app-server'].node.noChild === true){
 }
 
 if (cluster.isMaster) {
-  console.log('\nZWED5018I - Initializing with configuration:\n',JSON.stringify(configJSON, null, 2));
+  let configJSONSafeToPrint = Object.assign({}, configJSON);
+  if (configJSONSafeToPrint.zowe.sysMessages) {
+    delete configJSONSafeToPrint.zowe.sysMessages;
+  }
+
+  console.log('\nZWED5018I - Initializing with configuration:\n',JSON.stringify(configJSONSafeToPrint, null, 2));
 }
 module.exports = function() {
   return {configJSON: configJSON, configLocation: userInput.config}


### PR DESCRIPTION
Fixes https://github.com/zowe/launcher/issues/131
This is an weird case - this server prints out the sysMessages array that launcher uses to determine which lines to print to the syslog. By changing this server to just not print that array, the issue should be resolved.