### PR TITLE
Update references to nodejs cluster functions

### DIFF
--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -52,19 +52,19 @@ function getSafeToPrintEnvironment(env) {
 
 //Env overrides config JSON, -D args override env
 if(process.env.overrideFileConfig !== "false"){
-  if (cluster.isMaster) {
+  if (cluster.isPrimary) {
     const safeEnvironment = getSafeToPrintEnvironment(process.env);
     console.log('\nZWED5014I - Processing CLI arguments:\n'+commandArgs);
   }
   const envConfig = argParser.environmentVarsToObject("ZWED_");
   if (Object.keys(envConfig).length > 0) {
-    if (cluster.isMaster) {
+    if (cluster.isPrimary) {
       console.log('\nZWED5015I - Processed environment variables:\n'+JSON.stringify(envConfig, null, 2));
     }
     configJSON = Object.assign(configJSON, {components: {"app-server": mergeUtils.deepAssign(configJSON.components['app-server'], envConfig) } });
   }
   if (userInput.D) {
-    if (cluster.isMaster) {
+    if (cluster.isPrimary) {
       console.log('\nZWED5016I - Processed -D arguments:\n'+JSON.stringify(userInput.D, null, 2));
     }
     configJSON = Object.assign(configJSON, {components: {"app-server": mergeUtils.deepAssign(configJSON.components['app-server'], userInput.D) } })
@@ -78,7 +78,7 @@ if(configJSON.components['app-server'].node.noChild === true){
   delete configJSON.components['app-server'].node.childProcesses;
 }
 
-if (cluster.isMaster) {
+if (cluster.isPrimary) {
   let configJSONSafeToPrint = Object.assign({}, configJSON);
   if (configJSONSafeToPrint.zowe.sysMessages) {
     delete configJSONSafeToPrint.zowe.sysMessages;


### PR DESCRIPTION
Same as https://github.com/zowe/zlux-server-framework/pull/619

https://nodejs.org/api/cluster.html#clusterismaster has been aliased to https://nodejs.org/api/cluster.html#clusterisprimary since node 16, and marked as deprecated by them.

In order to avoid surprises if the old name is removed in the future, I'm changing references in our code to point to the right objects today.
node 16 isn't even supported anymore, so all nodes in support have the new name.

I'm not 100% confident that extenders are not using this.isMaster in our code, so I'm leaving that there and creating an alias to this.isPrimary for the sake of organization, so mimic node's behavior.
