### PR TITLE
Redirect `ipcrm` output to /dev/null

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.check-changelog.outputs.check_commit == 'false'
         id: extract-changelog
         run: |
-          PR_DESCRIPTION="\"${{ github.event.pull_request.body }}\""
+          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
           # Check if "changelog:" exists in PR description
           if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
             # Extract text after "changelog:"

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.check-changelog.outputs.check_commit == 'false'
         id: extract-changelog
         run: |
-          PR_DESCRIPTION=$(printf "%q" "${{ github.event.pull_request.body }}")
+          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
           # Check if "changelog:" exists in PR description
           if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
             # Extract text after "changelog:"

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.check-changelog.outputs.check_commit == 'false'
         id: extract-changelog
         run: |
-          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+          PR_DESCRIPTION="\"${{ github.event.pull_request.body }}\""
           # Check if "changelog:" exists in PR description
           if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
             # Extract text after "changelog:"

--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -73,7 +73,7 @@ jobs:
         if: steps.check-changelog.outputs.check_commit == 'false'
         id: extract-changelog
         run: |
-          PR_DESCRIPTION="${{ github.event.pull_request.body }}"
+          PR_DESCRIPTION=$(printf "%q" "${{ github.event.pull_request.body }}")
           # Check if "changelog:" exists in PR description
           if echo "$PR_DESCRIPTION" | grep -q "VERSION:" && echo "$PR_DESCRIPTION" | grep -q "CHANGELOG:"; then
             # Extract text after "changelog:"

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -68,7 +68,7 @@ if [ "${ZWE_RUN_ON_ZOS}" = "true" ]; then
       if [ $? -ne 0 ]; then
         kill -0 "$pidTwo" 1>/dev/null 2>&1
         if [ $? -ne 0 ]; then   # Neither pid exists, safe to remove q/m
-          ipcrm -$type $num
+          ipcrm -$type $num 1>/dev/null 2>&1
         fi
       fi
     fi
@@ -78,7 +78,7 @@ if [ "${ZWE_RUN_ON_ZOS}" = "true" ]; then
   for s in $(ipcs -sw | awk 'match($1,"s") && $3 == "'${id}'" { print "sem=\""$2"\";pid=\""$5"\"" }'); do
     eval "${s}"
     if [[ $pid -eq 0 ]]; then
-      ipcrm -s $sem
+      ipcrm -s $sem 1>/dev/null 2>&1
     fi
   done
 fi


### PR DESCRIPTION
Fixes https://github.com/zowe/zlux/issues/1072 - the `FOMI1076I` message will not be in the log.