### PR TITLE
Fix attls server config priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.5.0
-- Bugfix: App-server was not respecting property "components.app-server.zowe.network.tls.attls". Instead, property "zowe.network.tls.attls" was taking priority, [(#357)](https://github.com/zowe/zlux-app-server/pull/357)
+- Bugfix: App-server was not respecting property "components.app-server.zowe.network.server.tls.attls". Instead, property "zowe.network.server.tls.attls" was taking priority, [(#357)](https://github.com/zowe/zlux-app-server/pull/357)
 
 ## v3.4.0
 - Enhancement: Built-in apps such as 'zlux-editor', 'tn3270-ng2', 'vt-ng2' can now be enabled or disabled using the Zowe YAML with the same syntax as seen in other apps such as 'explorer-jes'. [(#346)](https://github.com/zowe/zlux-app-server/pull/346)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.5.0
-- Bugfix: App-server was not respecting property "components.app-server.zowe.network.server.tls.attls". Instead, property "zowe.network.server.tls.attls" was taking priority, [(#357)](https://github.com/zowe/zlux-app-server/pull/357)
+- Bugfix: App-server was not respecting property "components.app-server.zowe.network.server.tls.attls". Instead, property "zowe.network.server.tls.attls" was taking priority. [(#357)](https://github.com/zowe/zlux-app-server/pull/357)
 
 ## v3.4.0
 - Enhancement: Built-in apps such as 'zlux-editor', 'tn3270-ng2', 'vt-ng2' can now be enabled or disabled using the Zowe YAML with the same syntax as seen in other apps such as 'explorer-jes'. [(#346)](https://github.com/zowe/zlux-app-server/pull/346)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v3.5.0
+- Bugfix: App-server was not respecting property "components.app-server.zowe.network.tls.attls". Instead, property "zowe.network.tls.attls" was taking priority, [(#357)](https://github.com/zowe/zlux-app-server/pull/357)
+
 ## v3.4.0
 - Enhancement: Built-in apps such as 'zlux-editor', 'tn3270-ng2', 'vt-ng2' can now be enabled or disabled using the Zowe YAML with the same syntax as seen in other apps such as 'explorer-jes'. [(#346)](https://github.com/zowe/zlux-app-server/pull/346)
 - Enhancement: Added new flag in zowe.yaml 'enablePasswordChange' which controls the access to 'Change Password' tool in 'Personalization Panel'. [(#347)](https://github.com/zowe/zlux-app-server/pull/347)

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -21,6 +21,8 @@ components:
       http: "${{ function a() {
                 if (components['app-server'].zowe?.network?.server?.tls?.attls === true) {
                   return { 'port': components['app-server'].port || Number(7556)};
+                } else if (omponents['app-server'].zowe?.network?.server?.tls?.attls === false) {
+                  return undefined;
                 } else if (zowe.network?.server?.tls?.attls === true) {
                   return { 'port': components['app-server'].port || Number(7556)};
                 } else {
@@ -44,6 +46,10 @@ components:
         port: "${{ function a(){
                      if (components['app-server'].zowe?.network?.server?.tls?.attls === true) {
                        return undefined;
+                     } else if (components['app-server'].zowe?.network?.server?.tls?.attls === false) {
+                       return process.env.ZWED_SERVER_HTTPS_PORT ? Number(process.env.ZWED_SERVER_HTTPS_PORT) 
+                              : components['app-server'].port ? components['app-server'].port 
+                              : Number(7556);
                      } else if (zowe?.network?.server?.tls?.attls === true) {
                        return undefined;
                      } else if (process.env.ZWED_SERVER_HTTPS_PORT) {

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -21,7 +21,7 @@ components:
       http: "${{ function a() {
                 if (components['app-server'].zowe?.network?.server?.tls?.attls === true) {
                   return { 'port': components['app-server'].port || Number(7556)};
-                } else if (omponents['app-server'].zowe?.network?.server?.tls?.attls === false) {
+                } else if (components['app-server'].zowe?.network?.server?.tls?.attls === false) {
                   return undefined;
                 } else if (zowe.network?.server?.tls?.attls === true) {
                   return { 'port': components['app-server'].port || Number(7556)};


### PR DESCRIPTION
components.app-server.zowe.network.server.tls.attls should take priority over zowe.network.server.tls.attls

Yet, if you set

components.app-server.zowe.network.server.tls.attls:false
and 
zowe.network.server.tls.attls: true


You see in the logs,


ZWED0129I - (HTTP)...
Meaning that attls is on when it should be off.


This PR fixes that, it will instead say



WED0129I - (HTTP)...


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
