### PR TITLE
Fix ivy app2app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 ## v3.5.0
 - Bugfix: App-server was not respecting property "components.app-server.zowe.network.server.tls.attls". Instead, property "zowe.network.server.tls.attls" was taking priority. [(#357)](https://github.com/zowe/zlux-app-server/pull/357)
 - Bugfix: SSH and TELNET port detection may fail due to a lack of necessary permissions. [(#356)](https://github.com/zowe/zlux-app-server/pull/356)
+- Bugfix: Extension's bundled App2app files and default pinned plugins were not being deployed to the v3 desktop, and were only present in the v2 compatibility mode desktop. Now these files are correctly present in both desktop environments.
 
 ## v3.4.0
 - Enhancement: Built-in apps such as 'zlux-editor', 'tn3270-ng2', 'vt-ng2' can now be enabled or disabled using the Zowe YAML with the same syntax as seen in other apps such as 'explorer-jes'. [(#346)](https://github.com/zowe/zlux-app-server/pull/346)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 ## v3.5.0
 - Bugfix: App-server was not respecting property "components.app-server.zowe.network.server.tls.attls". Instead, property "zowe.network.server.tls.attls" was taking priority. [(#357)](https://github.com/zowe/zlux-app-server/pull/357)
 - Bugfix: SSH and TELNET port detection may fail due to a lack of necessary permissions. [(#356)](https://github.com/zowe/zlux-app-server/pull/356)
-- Bugfix: Extension's bundled App2app files and default pinned plugins were not being deployed to the v3 desktop, and were only present in the v2 compatibility mode desktop. Now these files are correctly present in both desktop environments.
+- Bugfix: Extension's bundled App2app files and default pinned plugins were not being deployed to the v3 desktop, and were only present in the v2 compatibility mode desktop. Now these files are correctly present in both desktop environments. [(#359)](https://github.com/zowe/zlux-app-server/pull/359)
 
 ## v3.4.0
 - Enhancement: Built-in apps such as 'zlux-editor', 'tn3270-ng2', 'vt-ng2' can now be enabled or disabled using the Zowe YAML with the same syntax as seen in other apps such as 'explorer-jes'. [(#346)](https://github.com/zowe/zlux-app-server/pull/346)

--- a/bin/internal-install.sh
+++ b/bin/internal-install.sh
@@ -77,6 +77,10 @@ chmod -R u+w zlux-app-server 2>/dev/null
 
 mkdir -p zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.ng2desktop/ui/launchbar/plugins
 cp -f ${ZWED_INSTALL_DIR}/files/zlux/config/pinnedPlugins.json zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.ng2desktop/ui/launchbar/plugins/
+
+mkdir -p zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.ivydesktop/ui/launchbar/plugins
+cp -f ${ZWED_INSTALL_DIR}/files/zlux/config/pinnedPlugins.json zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.ivydesktop/ui/launchbar/plugins/
+
 mkdir -p zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins
 cp -f ${ZWED_INSTALL_DIR}/files/zlux/config/allowedPlugins.json zlux-app-server/defaults/ZLUX/pluginStorage/org.zowe.zlux.bootstrap/plugins/
 rm zlux-app-server/defaults/plugins/*

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -55,12 +55,15 @@ initUtils.mkdirp(sitePluginStorage, initUtils.FOLDER_MODE);
 if (!config.instanceDir) {
   config.instanceDir = destination;
 }
+
+const desktopPlugins = ['ng2desktop', 'ivydesktop'];
+
 const instancePluginStorage = path.join(config.instanceDir, 'ZLUX', 'pluginStorage');
 initUtils.mkdirp(instancePluginStorage, initUtils.FOLDER_MODE);
-const recognizersPluginStorage = path.join(config.instanceDir, 'ZLUX/pluginStorage', 'org.zowe.zlux.ng2desktop/recognizers');
-initUtils.mkdirp(recognizersPluginStorage, initUtils.FOLDER_MODE);
-const actionsPluginStorage = path.join(config.instanceDir, 'ZLUX/pluginStorage/org.zowe.zlux.ng2desktop', 'actions');
-initUtils.mkdirp(actionsPluginStorage, initUtils.FOLDER_MODE);
+const recognizersPluginStorages = desktopPlugins.map(plugin => path.join(config.instanceDir, 'ZLUX/pluginStorage', `org.zowe.zlux.${plugin}/recognizers`));
+recognizersPluginStorages.forEach(recognizersPluginStorage => initUtils.mkdirp(recognizersPluginStorage, initUtils.FOLDER_MODE));
+const actionsPluginStorages = desktopPlugins.map(plugin => path.join(config.instanceDir, `ZLUX/pluginStorage/org.zowe.zlux.${plugin}`, 'actions'));
+actionsPluginStorages.forEach(actionsPluginStorage => initUtils.mkdirp(actionsPluginStorage, initUtils.FOLDER_MODE));
 
 const instanceConfig = path.join(config.instanceDir, 'serverConfig');
 //750 specifically, to keep server config secure
@@ -280,10 +283,10 @@ INSTALLED_COMPONENTS.forEach(function(installedComponent) {
           const pluginDefinitionJson = JSON.parse(fs.readFileSync(pluginDefinition, 'utf8'));
           if (enabled) {
             initUtils.printFormattedInfo(`Registering plugin ${fullPath}`);
-            initUtils.registerPlugin(fullPath, pluginDefinitionJson, config.pluginsDir, actionsPluginStorage, recognizersPluginStorage, RUNTIME_DIRECTORY);
+            initUtils.registerPlugin(fullPath, pluginDefinitionJson, config.pluginsDir, actionsPluginStorages, recognizersPluginStorages, RUNTIME_DIRECTORY);
           } else {
             initUtils.printFormattedDebug(`Deregistering plugin ${fullPath}`);
-            initUtils.deregisterPlugin(pluginDefinitionJson, config.pluginsDir, actionsPluginStorage);
+            initUtils.deregisterPlugin(pluginDefinitionJson, config.pluginsDir, actionsPluginStorages);
           }
         } else {
           initUtils.printFormattedError(`Skipping plugin at ${fullPath} due to pluginDefinition missing or invalid`);

--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -123,7 +123,7 @@ function fileExists(file) {
 module.exports.fileExists = fileExists;
 
 
-function deregisterPlugin(pluginDefinition, pluginPointerDirectory, actionsDirectory) {
+function deregisterPlugin(pluginDefinition, pluginPointerDirectory, actionsDirectories) {
   const filePath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
   if (fileExists(filePath, true)) {
     try {
@@ -133,12 +133,14 @@ function deregisterPlugin(pluginDefinition, pluginPointerDirectory, actionsDirec
     }
     return true;
   } else {
-    return deregisterApp2App(pluginDefinition.identifier, actionsDirectory);
+    return deregisterApp2App(pluginDefinition.identifier, actionsDirectories);
   }
 }
 module.exports.deregisterPlugin = deregisterPlugin;
 
-function deregisterApp2App(appId, actionsDirectory) {
+function deregisterApp2App(appId, actionsDirectories) {
+  let exists = false;
+  actionsDirectories.forEach((actionsDirectory) => {
   const actionPath = path.join(actionsDirectory, appId);
   if (fileExists(actionPath, true)) {
     try {
@@ -146,22 +148,24 @@ function deregisterApp2App(appId, actionsDirectory) {
     } catch (e) {
       printFormattedError(`Could not deregister plugin ${appId}, delete ${actionPath} failed, error=${e}`);
     }
-    return true;
+    exists = true;
   }
+  });
+  return exists;
   //TODO how to deregister recognizer?
 }
 module.exports.deregisterApp2App = deregisterApp2App;
 
 
 
-function registerApp2App(pluginDirectory, pluginId, pluginVersion, pluginActionsLocation, pluginRecognizersLocation) {
+function registerApp2App(pluginDirectory, pluginId, pluginVersion, pluginActionsLocations, pluginRecognizersLocations) {
   printFormattedDebug(`app2app for ${pluginId}`);
-  copyRecognizers(pluginDirectory, pluginId, pluginVersion, pluginRecognizersLocation);
-  copyActions(pluginDirectory, pluginId, pluginVersion, pluginActionsLocation);
+  copyRecognizers(pluginDirectory, pluginId, pluginVersion, pluginRecognizersLocations);
+  copyActions(pluginDirectory, pluginId, pluginVersion, pluginActionsLocations);
 }
 module.exports.registerApp2App = registerApp2App;
 
-function copyRecognizers(appDir, appId, appVers, recognizerDirectory) {
+function copyRecognizers(appDir, appId, appVers, recognizerDirectories) {
   let recognizers;
   let recognizersKeys;
   let configRecognizers;
@@ -174,7 +178,6 @@ function copyRecognizers(appDir, appId, appVers, recognizerDirectory) {
     .forEach((statObj) => {
       const filename = statObj.name;
       const filepath = path.resolve(pluginRecognizersLocation, filename);
-      const filepathConfig = path.resolve(path.join(recognizerDirectory, filename));
       
       recognizers = JSON.parse(fs.readFileSync(filepath, 'utf8')).recognizers;
       recognizersKeys = Object.keys(recognizers)
@@ -184,6 +187,8 @@ function copyRecognizers(appDir, appId, appVers, recognizerDirectory) {
         recognizers[key].key = appId + ":" + key + ":" + recognizers[key].id; // pluginid_that_provided_it:index(or_name)_in_that_provider:actionid
       }
       printFormattedDebug(`ZWED0301I Found ${filepath} in config for '${appId}'`);
+      recognizerDirectories.forEach((recognizerDirectory) => {
+      const filepathConfig = path.resolve(path.join(recognizerDirectory, filename));
       printFormattedDebug(`Going to merge into ${filepathConfig}`);
       try { // Get pre-existing recognizers in config, if any
         configRecognizers = fileExists(filepathConfig) ? JSON.parse(fs.readFileSync(filepathConfig, 'utf8')).recognizers : {};
@@ -199,8 +204,11 @@ function copyRecognizers(appDir, appId, appVers, recognizerDirectory) {
       } catch (e) {
         printFormattedError(`Error: Invalid JSON for ${filepathConfig}`);
       }
+      });
       
       if (recognizers) { // Attempt to copy recognizers over to config location for Desktop access later
+        recognizerDirectories.forEach((recognizerDirectory) => {
+        const filepathConfig = path.resolve(path.join(recognizerDirectory, filename));
         try { //TODO: Doing recognizers.recognizers is redundant. We may want to consider refactoring in the future
           fs.writeFileSync(filepathConfig, '{ "recognizers":' + JSON.stringify(recognizers) + '}',
                            {encoding: 'utf8', mode: FILE_MODE});
@@ -208,6 +216,7 @@ function copyRecognizers(appDir, appId, appVers, recognizerDirectory) {
         } catch (e) {
           printFormattedError(`ZWED0177W Unable to load ${recognizers} for '${appId}' into config`);
         }
+        });
       }
       
     });
@@ -215,7 +224,7 @@ function copyRecognizers(appDir, appId, appVers, recognizerDirectory) {
   printFormattedDebug(`Done rec`);
 }
 
-function copyActions(appDir, appId, appVers, actionsDirectory) {
+function copyActions(appDir, appId, appVers, actionsDirectories) {
   let actions;
   let actionsKeys;
   const pluginActionsLocation = path.join(appDir, "config", "actions", appId);
@@ -236,9 +245,11 @@ function copyActions(appDir, appId, appVers, actionsDirectory) {
 
     if (actions) { // Attempt to copy actions over to config location for Desktop access later
       try { //TODO: Doing actions.actions is redundant. We may want to consider refactoring in the future
+        actionsDirectories.forEach((actionsDirectory) => {
         fs.writeFileSync(path.join(actionsDirectory, appId), '{ "actions":' + JSON.stringify(actions) + '}',
                          {encoding: 'utf8', mode: FILE_MODE});
-        printFormattedInfo("ZWED0295I Successfully loaded " + actions.length + " actions for '" + appId + "' into config at "+path.join(actionsDirectory, appId));
+          printFormattedInfo("ZWED0295I Successfully loaded " + actions.length + " actions for '" + appId + "' into config at "+path.join(actionsDirectory, appId));
+        });
       } catch (e) {
         printFormattedError(`ZWED0177W Unable to load ${actions} for '${appId}' into config`);
       }
@@ -248,7 +259,7 @@ function copyActions(appDir, appId, appVers, actionsDirectory) {
 }
 
 
-function registerPlugin(pluginPath, pluginDefinition, pluginPointerDirectory, pluginActionsLocation, pluginRecognizersLocation, runtimeDirectory) {
+function registerPlugin(pluginPath, pluginDefinition, pluginPointerDirectory, pluginActionsLocations, pluginRecognizersLocations, runtimeDirectory) {
   const pointerPath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`; 
   let location, relativeTo;
   if (pluginPath.startsWith(runtimeDirectory)) {
@@ -269,7 +280,7 @@ function registerPlugin(pluginPath, pluginDefinition, pluginPointerDirectory, pl
       "pluginLocation": pluginPath
     }, null, 2), {encoding: 'utf8', mode: FILE_MODE});
   }
-  registerApp2App(pluginPath, pluginDefinition.identifier, pluginDefinition.pluginVersion, pluginActionsLocation, pluginRecognizersLocation);
+  registerApp2App(pluginPath, pluginDefinition.identifier, pluginDefinition.pluginVersion, pluginActionsLocations, pluginRecognizersLocations);
 }
 module.exports.registerPlugin = registerPlugin;
 


### PR DESCRIPTION
Files such as pinnedPlugins.json and extension app2app recognizers/actions were only being copied to the ng2desktop workspace folder but not the ivydesktop one.
At this time, there really isnt a difference between assets of the two, so the simplest way to resolve this is to just copy such assets into both places.

This is one of 3 PRs that should go together. Needs:
https://github.com/zowe/zlux-build/pull/159
https://github.com/zowe/zlux-server-framework/pull/667