### PR TITLE
Add dual cert support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.5.0
+- Enhancement: App-server startup no longer runs certificate validation as that has been migrated to the zwe launcher startup process to work for all components. [(#364)](https://github.com/zowe/zlux-app-server/pull/364)
 - Enhancement: App-server now supports separate server and client TLS certificates. Define `zowe.certificate.keystore.clientCertificateAlias` (for keyrings) or `zowe.certificate.pem.clientCertificate` and `zowe.certificate.pem.clientKey` (for PEM files) to use a dedicated client certificate for all outbound connections. The main certificate continues to be used for serving HTTPS. When not defined, the existing certificate is used for both as before. [(#365)](https://github.com/zowe/zlux-app-server/pull/365) [(#364)](https://github.com/zowe/zlux-app-server/pull/364)
 - Bugfix: App-server was not respecting property "components.app-server.zowe.network.server.tls.attls". Instead, property "zowe.network.server.tls.attls" was taking priority. [(#357)](https://github.com/zowe/zlux-app-server/pull/357)
 - Bugfix: SSH and TELNET port detection may fail due to a lack of necessary permissions. [(#356)](https://github.com/zowe/zlux-app-server/pull/356)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.5.0
-- Enhancement: App-server startup no longer runs certificate validation as that has been migrated to the zwe launcher startup process to work for all components. [(#364)](https://github.com/zowe/zlux-app-server/pull/364)
+- Enhancement: App-server now supports separate server and client TLS certificates. Define `zowe.certificate.keystore.clientCertificateAlias` (for keyrings) or `zowe.certificate.pem.clientCertificate` and `zowe.certificate.pem.clientKey` (for PEM files) to use a dedicated client certificate for all outbound connections. The main certificate continues to be used for serving HTTPS. When not defined, the existing certificate is used for both as before. [(#365)](https://github.com/zowe/zlux-app-server/pull/365) [(#364)](https://github.com/zowe/zlux-app-server/pull/364)
 - Bugfix: App-server was not respecting property "components.app-server.zowe.network.server.tls.attls". Instead, property "zowe.network.server.tls.attls" was taking priority. [(#357)](https://github.com/zowe/zlux-app-server/pull/357)
 - Bugfix: SSH and TELNET port detection may fail due to a lack of necessary permissions. [(#356)](https://github.com/zowe/zlux-app-server/pull/356)
 - Bugfix: Extension's bundled App2app files and default pinned plugins were not being deployed to the v3 desktop, and were only present in the v2 compatibility mode desktop. Now these files are correctly present in both desktop environments. [(#359)](https://github.com/zowe/zlux-app-server/pull/359)

--- a/defaults/serverConfig/defaults.yaml
+++ b/defaults/serverConfig/defaults.yaml
@@ -74,6 +74,24 @@ components:
                              } else {
                                return [ "../defaults/serverConfig/zlux.keystore.cer" ]; } };
                         a() }}'
+        clientKeys: '${{ function a() {
+                           if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")
+                               && zowe.certificate?.keystore?.clientCertificateAlias) {
+                             return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.clientCertificateAlias ];
+                           } else if (zowe.certificate?.pem?.clientKey) {
+                             return [ zowe.certificate.pem.clientKey ];
+                           } else {
+                             return undefined; } };
+                      a() }}'
+        clientCertificates: '${{ function a() {
+                                   if (zowe.certificate?.keystore?.type && zowe.certificate.keystore.type.match("JCE.*KS")
+                                       && zowe.certificate?.keystore?.clientCertificateAlias) {
+                                     return [ zowe.certificate.keystore.file+"&"+zowe.certificate.keystore.clientCertificateAlias ];
+                                   } else if (zowe.certificate?.pem?.clientCertificate) {
+                                     return [ zowe.certificate.pem.clientCertificate ];
+                                   } else {
+                                     return undefined; } };
+                              a() }}'
         certificateAuthorities: '${{ function a() {
                                        if (zowe.certificate?.truststore?.type && zowe.certificate.truststore.type.match("JCE.*KS")) {
                                           return [ zowe.certificate.truststore.file ];

--- a/schemas/app-server-config.json
+++ b/schemas/app-server-config.json
@@ -45,6 +45,14 @@
             "certificates": {
               "$ref": "#/$defs/certObject"
             },
+            "clientKeys": {
+              "$ref": "#/$defs/certObject",
+              "description": "Key file(s) for outbound client TLS connections. When set alongside clientCertificates, these are used instead of the server keys for client connections, allowing server and client certificates to differ."
+            },
+            "clientCertificates": {
+              "$ref": "#/$defs/certObject",
+              "description": "Certificate file(s) for outbound client TLS connections. When set alongside clientKeys, these are used instead of the server certificates for client connections, allowing server and client certificates to differ."
+            },
             "certificateAuthorities": {
               "$ref": "#/$defs/certObject"
             },


### PR DESCRIPTION
<!-- Thank you for submitting a PR to Zowe! To help us understand, test, and give feedback on your code, please fill in the details below. -->

## Proposed changes
<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

This PR adds support for configuring a separate client TLS certificate distinct from the server TLS certificate. Previously, the single `zowe.certificate` entry was used for both serving inbound HTTPS and making outbound client connections (to ZSS, APIML, auth plugins, etc.). This works when the certificate has an EKU that permits both uses, but some deployments require separate server-only and client-only certificates.

When the optional properties are defined, the new client certificate is used for all outbound connections while the main certificate is used exclusively for serving HTTPS. When the properties are absent, behavior is unchanged from before (backward compatible).

This PR depends upon the following PRs:
- zlux-server-framework: https://github.com/zowe/zlux-server-framework/pull/674

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
- [ ] video or image is included if visual changes are made
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works, or describe a test method below

## Testing

**Keyring (JCERACFKS) path:** Define `zowe.certificate.keystore.clientCertificateAlias` in zowe.yaml alongside an existing keyring configuration. Verify that the app-server logs `ZWED0305I` on startup and that outbound connections (to ZSS/agent) use the identity from `clientCertificateAlias` rather than the main `alias`.

**PEM path:** Define both `zowe.certificate.pem.clientCertificate` and `zowe.certificate.pem.clientKey` in zowe.yaml alongside an existing PEM configuration. Verify that `ZWED0305I` is logged and outbound connections use the client PEM files.

**Backward compatibility:** Remove the above optional properties (or leave a default config with no client cert fields). Verify the server starts and behaves identically to before: the main certificate is used for both inbound and outbound TLS.

## Further comments

Changes in this PR are limited to `defaults/serverConfig/defaults.yaml` and `schemas/app-server-config.json`. The implementation of the split itself lives in the companion zlux-server-framework PR (#674):

- **`defaults/serverConfig/defaults.yaml`**: Added `clientKeys` and `clientCertificates` template expressions under `node.https`. These resolve to the client alias or PEM file paths when `zowe.certificate.keystore.clientCertificateAlias` (keyrings) or `zowe.certificate.pem.clientCertificate`/`zowe.certificate.pem.clientKey` (PEM) are present, and to `undefined` otherwise — which triggers the backward-compatible single-certificate path in the server framework.

- **`schemas/app-server-config.json`**: Added `clientKeys` and `clientCertificates` as documented optional properties in the `node.https` schema.
