### PR TITLE
Cleanup install/uninstall scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Zlux App Server package will be documented in this file.
 
+## v3.6.0
+- Enhancement: Added `components.app-server.loadPreference` configuration property (`manifest` or `dir`, default `manifest`). When the app-server discovers the same plugin from both a component manifest and a `pluginsDir` pointer file, this property determines which source takes priority.
+- Bugfix: Installation of apps in containers would not handle app2app actions files.
+
 ## v3.5.0
 - Enhancement: App-server startup no longer runs certificate validation as that has been migrated to the zwe launcher startup process to work for all components. [(#364)](https://github.com/zowe/zlux-app-server/pull/364)
 - Enhancement: App-server now supports separate server and client TLS certificates. Define `zowe.certificate.keystore.clientCertificateAlias` (for keyrings) or `zowe.certificate.pem.clientCertificate` and `zowe.certificate.pem.clientKey` (for PEM files) to use a dedicated client certificate for all outbound connections. The main certificate continues to be used for serving HTTPS. When not defined, the existing certificate is used for both as before. [(#365)](https://github.com/zowe/zlux-app-server/pull/365) [(#364)](https://github.com/zowe/zlux-app-server/pull/364)

--- a/bin/install-app.sh
+++ b/bin/install-app.sh
@@ -27,8 +27,7 @@ if [ -n "${ZWE_zowe_workspaceDirectory}" -a -n "${ZWE_zowe_runtimeDirectory}" ];
   if [ "${ZWE_RUN_ON_ZOS}" != "true" ]; then
     if [ -f "/component/manifest.yaml" -o -f "/component/manifest.json" -o -f "/component/manifest.yml" ]; then
       COMPONENT_HOME=/component
-      ZLUX_CONTAINER_MODE=1  
-      INSTALL_NO_NODE=1  
+      ZLUX_CONTAINER_MODE=1
     fi
     if [ ! -d "${COMPONENT_HOME}/share/zlux-app-server" ]; then
       COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/app-server
@@ -36,7 +35,7 @@ if [ -n "${ZWE_zowe_workspaceDirectory}" -a -n "${ZWE_zowe_runtimeDirectory}" ];
   fi
   zlux_path="$COMPONENT_HOME/share"
 
-  if [ -z "$INSTALL_NO_NODE" ]; then
+  if [ -z "$ZLUX_CONTAINER_MODE" ]; then
     setVars
     if [ ! -e "${ZWE_zowe_workspaceDirectory}/app-server/plugins/org.zowe.zlux.json" ]; then
       cd ${zlux_path}/zlux-app-server/lib
@@ -50,9 +49,6 @@ fi
 
 . ${zlux_path}/zlux-app-server/bin/utils/plugin-utils.sh
 
-
-
-utils_path=$zlux_path/zlux-server-framework/utils
 #app_path=$(cd "$1"; pwd)
 app_path=$1
 if [ $# -gt 1 ]; then
@@ -71,9 +67,14 @@ fi
 mkdir -p $plugin_dir
 
 
-# Installs a zowe plugin by finding its ID and writing the locator json WITHOUT using install-app.js
-# This is to be used in cases where there are issues using JS, or nodejs is not found.
-# Input: relative or fully qualified path to a directory containing a plugindir=$(cd `dirname $0` && pwd)
+# Installs a zowe plugin by finding its ID and writing the locator json WITHOUT using Node.js.
+# Used in container mode where Node is not available.
+# Note: unlike the Node path, metadata enrichment and recognizer merging are not
+# performed here as JSON processing is not available in shell. Recognizer registration
+# is skipped entirely; actions are copied as-is without metadata or merge.
+# TODO: recognizer registration is not implemented in the container path. Shell-based
+# JSON merging is not feasible without external tooling (e.g. jq). A future improvement
+# would invoke a minimal Node.js script for this step if Node becomes available in containers.
 installNojs() {
   id=$(getPluginID "${app_path}")
   if [ -n "${id}" ]; then
@@ -90,6 +91,24 @@ EOF
     if [ -f "${plugin_dir}/${id}.json" ]; then
       chmod 0771 "${plugin_dir}/${id}.json"
     fi
+
+    # Copy app2app actions and recognizers to desktop plugin storages
+    CONTAINER_INSTANCE_DIR="${ZWED_instanceDir:-${ZWE_zowe_workspaceDirectory}/app-server}"
+    if [ -n "${CONTAINER_INSTANCE_DIR}" ]; then
+      for desktop_plugin in ng2desktop ivydesktop; do
+        if [ -f "${app_path}/config/actions/${id}" ]; then
+          actions_dir="${CONTAINER_INSTANCE_DIR}/ZLUX/pluginStorage/org.zowe.zlux.${desktop_plugin}/actions"
+          mkdir -p "${actions_dir}"
+          cp "${app_path}/config/actions/${id}" "${actions_dir}/${id}"
+        fi
+      done
+    else
+      echo "Warning: could not determine instance directory, skipping app2app registration"
+    fi
+    # TODO: recognizer registration is not performed in container mode (see comment above)
+    if [ -d "${app_path}/config/recognizers" ]; then
+      echo "Warning: plugin ${id} contains recognizers but recognizer registration is not supported in container mode. Recognizers will not be active until the server is restarted in a non-container environment."
+    fi
   else
     echo "Error: could not find plugin id for path=${app_path}"
     exit 1
@@ -97,37 +116,37 @@ EOF
 }
 
 
-if [ -n "$INSTALL_NO_NODE" ]; then
+if [ -n "$ZLUX_CONTAINER_MODE" ]; then
   installNojs
 else
-  cd $zlux_path/zlux-app-server/bin
-
   echo "Testing if node exists"
   type ${NODE_BIN}
-  rc=$?
-  if [ $rc -ne 0 ]; then
-    installNojs
-  else
-    # normal case follows
-    if [ -z "$ZLUX_INSTALL_LOG_DIR" ]; then
-      if [ -d "${ZWE_zowe_logDirectory}" ]; then
-        ZLUX_INSTALL_LOG_DIR="$ZWE_zowe_logDirectory"
-      fi
-    fi
-
-    PLUGIN_LOG_FILE=/dev/null
-    if [ ! -z "$ZLUX_INSTALL_LOG_DIR" ]; then
-      if [ ! -d "$ZLUX_INSTALL_LOG_DIR" ]; then
-        echo "Will make log directory $ZLUX_INSTALL_LOG_DIR"
-        mkdir -p $ZLUX_INSTALL_LOG_DIR
-      fi
-      PLUGIN_LOG_FILE="$ZLUX_INSTALL_LOG_DIR/install-app.log"
-    fi
-
-
-    echo "Running app-server plugin registration. Log=$PLUGIN_LOG_FILE"
-    echo "utils_path=${utils_path}\napp_path=${app_path}"
-    echo "plugin_dir=${plugin_dir}"
-    { ${NODE_BIN} ${utils_path}/install-app.js -i "$app_path" -p "$plugin_dir" $@ 2>&1 ; echo "Plugin registration ended with rc=$?" ; } | tee -a $PLUGIN_LOG_FILE
+  if [ $? -ne 0 ]; then
+    echo "Error: node not found, cannot register plugin"
+    echo "Plugin registration ended with rc=1"
+    exit 1
   fi
+
+  # normal case follows
+  if [ -z "$ZLUX_INSTALL_LOG_DIR" ]; then
+    if [ -d "${ZWE_zowe_logDirectory}" ]; then
+      ZLUX_INSTALL_LOG_DIR="$ZWE_zowe_logDirectory"
+    fi
+  fi
+
+  PLUGIN_LOG_FILE=/dev/null
+  if [ ! -z "$ZLUX_INSTALL_LOG_DIR" ]; then
+    if [ ! -d "$ZLUX_INSTALL_LOG_DIR" ]; then
+      echo "Will make log directory $ZLUX_INSTALL_LOG_DIR"
+      mkdir -p $ZLUX_INSTALL_LOG_DIR
+    fi
+    PLUGIN_NICKNAME=$(basename "$app_path")
+    PLUGIN_TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+    PLUGIN_LOG_FILE="$ZLUX_INSTALL_LOG_DIR/install-app-${PLUGIN_NICKNAME}-${PLUGIN_TIMESTAMP}.log"
+  fi
+
+  echo "Running app-server plugin registration. Log=$PLUGIN_LOG_FILE"
+  echo "app_path=${app_path}"
+  echo "plugin_dir=${plugin_dir}"
+  { ${NODE_BIN} ${zlux_path}/zlux-app-server/lib/install-app.js -i "$app_path" -p "$plugin_dir" $@ 2>&1 ; echo "Plugin registration ended with rc=$?" ; } | tee -a $PLUGIN_LOG_FILE
 fi

--- a/bin/uninstall-app.bat
+++ b/bin/uninstall-app.bat
@@ -2,9 +2,9 @@
 REM This program and the accompanying materials are
 REM made available under the terms of the Eclipse Public License v2.0 which accompanies
 REM this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
-REM 
+REM
 REM SPDX-License-Identifier: EPL-2.0
-REM 
+REM
 REM Copyright Contributors to the Zowe Project.
 if [%1]==[] goto :fail
 setlocal EnableDelayedExpansion
@@ -39,19 +39,8 @@ if defined ZWE_zowe_runtimeDirectory (
 REM ---- Node module path ----
 set NODE_PATH=!ZLUX_ROOT_DIR!;!ZLUX_ROOT_DIR!\zlux-server-framework\node_modules;%NODE_PATH%
 
-REM ---- Workspace initialization (production only) ----
-if defined ZWE_zowe_runtimeDirectory (
-  if defined ZWE_zowe_workspaceDirectory (
-    if not exist "!ZWE_zowe_workspaceDirectory!\app-server\plugins\org.zowe.zlux.json" (
-      cd "!ZLUX_APP_SERVER_DIR!\lib"
-      !NODE_BIN! initInstance.js
-      cd "!SCRIPT_DIR!"
-    )
-  )
-)
-
-REM ---- App path (argument 1) ----
-set app_path=%~f1
+REM ---- App input (argument 1): plugin ID or path ----
+set app_input=%1
 
 REM ---- Plugin directory ----
 REM Use explicit second argument if provided; otherwise resolve from env vars.
@@ -71,10 +60,9 @@ if not [%2]==[] (
 
 if not defined plugin_dir (
   echo Error: could not find plugin directory
-  echo Plugin registration ended with rc=1
+  echo Plugin deregistration ended with rc=1
   exit /B 1
 )
-call :makedir "!plugin_dir!"
 
 REM ---- Log file setup ----
 if not defined ZLUX_INSTALL_LOG_DIR (
@@ -86,37 +74,35 @@ if not defined ZLUX_INSTALL_LOG_DIR (
 set PLUGIN_LOG_FILE=nul
 if defined ZLUX_INSTALL_LOG_DIR (
   call :makedir "!ZLUX_INSTALL_LOG_DIR!"
-  for %%a in ('powershell -NoProfile -Command "[datetime]::Now.ToString(''yyyyMMdd-HHmmss'')"') do set PLUGIN_TIMESTAMP=%%a
   for /f %%a in ('powershell -NoProfile -Command "[datetime]::Now.ToString(''yyyyMMdd-HHmmss'')"') do set PLUGIN_TIMESTAMP=%%a
-  for %%a in ("%app_path%") do set PLUGIN_NICKNAME=%%~nxa
-  set PLUGIN_LOG_FILE=!ZLUX_INSTALL_LOG_DIR!\install-app-!PLUGIN_NICKNAME!-!PLUGIN_TIMESTAMP!.log
+  for %%a in ("%app_input%") do set PLUGIN_NICKNAME=%%~nxa
+  set PLUGIN_LOG_FILE=!ZLUX_INSTALL_LOG_DIR!\uninstall-app-!PLUGIN_NICKNAME!-!PLUGIN_TIMESTAMP!.log
 )
 
 REM ---- Check node ----
 echo Testing if node exists
 !NODE_BIN! --version >nul 2>&1
 if errorlevel 1 (
-  echo Error: node not found, cannot register plugin
-  echo Plugin registration ended with rc=1
+  echo Error: node not found, cannot deregister plugin
+  echo Plugin deregistration ended with rc=1
   exit /B 1
 )
 
-REM ---- Run installer ----
-echo Running app-server plugin registration. Log=!PLUGIN_LOG_FILE!
-echo app_path=!app_path!
+REM ---- Run uninstaller ----
+echo Running app-server plugin deregistration. Log=!PLUGIN_LOG_FILE!
+echo app_input=!app_input!
 echo plugin_dir=!plugin_dir!
-!NODE_BIN! "!ZLUX_APP_SERVER_DIR!\lib\install-app.js" -i "!app_path!" -p "!plugin_dir!" >> "!PLUGIN_LOG_FILE!" 2>&1
+!NODE_BIN! "!ZLUX_APP_SERVER_DIR!\lib\uninstall-app.js" -i "!app_input!" -p "!plugin_dir!" >> "!PLUGIN_LOG_FILE!" 2>&1
 set rc=%ERRORLEVEL%
-echo Plugin registration ended with rc=%rc%
+echo Plugin deregistration ended with rc=%rc%
 endlocal
 exit /B %rc%
 
 :fail
-echo Usage: install-app.bat AppPath [PluginsDir]
+echo Usage: uninstall-app.bat AppID^|AppPath [PluginsDir]
 exit /B 1
 
 REM Create a directory if it does not exist yet.
 :makedir
 if not exist %1 mkdir %1
 goto :eof
-

--- a/bin/uninstall-app.sh
+++ b/bin/uninstall-app.sh
@@ -6,33 +6,51 @@
 # SPDX-License-Identifier: EPL-2.0
 # 
 # Copyright Contributors to the Zowe Project.
-if [ $# -eq 0 ]
-  then
+
+if [ $# -eq 0 ]; then
   echo "Usage: $0 AppID|AppPath [PluginsDir]"
   exit 1
 fi
 
-export _CEE_RUNOPTS="FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
-export _EDC_ADD_ERRNO2=1                        # show details on error
-unset ENV             # just in case, as it can cause unexpected output
+setVars() {
+  export _CEE_RUNOPTS="FILETAG(AUTOCVT,AUTOTAG) POSIX(ON)"
+  export _EDC_ADD_ERRNO2=1                        # show details on error
+  unset ENV             # just in case, as it can cause unexpected output
+  umask 0002                                       # similar to chmod 755
+  . ${zlux_path}/zlux-app-server/bin/init/node-init.sh
+}
 
-dir=$(cd `dirname $0` && pwd)
-. $dir/utils/plugin-utils.sh
+if [ -n "${ZWE_zowe_workspaceDirectory}" -a -n "${ZWE_zowe_runtimeDirectory}" ]; then
+  COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/app-server
 
-if [ -d "$1" ]; then
-  arg_path="true"
-  app_path=$(cd "$1"; pwd)  
+  # containers only
+  if [ "${ZWE_RUN_ON_ZOS}" != "true" ]; then
+    if [ -f "/component/manifest.yaml" -o -f "/component/manifest.json" -o -f "/component/manifest.yml" ]; then
+      COMPONENT_HOME=/component
+      ZLUX_CONTAINER_MODE=1
+    fi
+    if [ ! -d "${COMPONENT_HOME}/share/zlux-app-server" ]; then
+      COMPONENT_HOME=${ZWE_zowe_runtimeDirectory}/components/app-server
+    fi
+  fi
+  zlux_path="$COMPONENT_HOME/share"
+
+  if [ -z "$ZLUX_CONTAINER_MODE" ]; then
+    setVars
+  fi
 else
-  arg_path="false"
-  app_id="$1"
+  zlux_path=$(cd $(dirname "$0")/../..; pwd)
+  setVars
 fi
 
+. ${zlux_path}/zlux-app-server/bin/utils/plugin-utils.sh
+
+app_input=$1
 if [ $# -gt 1 ]; then
   plugin_dir=$2
   shift
 else
-  getPluginsDir
-  plugin_dir=$?
+  plugin_dir=$(getPluginsDir)
 fi
 shift
 
@@ -43,33 +61,79 @@ if [ -z "$plugin_dir" ]; then
 fi
 
 
-if [ "$arg_path" = "true" ]; then
-  id=$(getPluginID "${app_path}")
-  
-  if [ -n "${id}" ]; then
-    echo "Found plugin=${id}"
-    app_id=$id
+# Deregisters a zowe plugin by removing its locator JSON WITHOUT using Node.js.
+# Used in container mode where Node is not available.
+uninstallNojs() {
+  # Determine identifier: if a directory was given, extract from pluginDefinition.json;
+  # otherwise treat the argument as a bare identifier.
+  if [ -d "${app_input}" ]; then
+    id=$(getPluginID "${app_input}")
+    if [ -z "${id}" ]; then
+      echo "Error: could not find plugin id for path=${app_input}"
+      echo "Plugin deregistration ended with rc=1"
+      exit 1
+    fi
   else
-    echo "Error: could not find plugin id for path=${app_path}"
+    id="${app_input}"
+  fi
+
+  echo "Deregistering plugin=${id}"
+  if [ -e "${plugin_dir}/${id}.json" ]; then
+    rm "${plugin_dir}/${id}.json"
+    echo "Plugin deregistration ended with rc=$?"
+  else
+    echo "Plugin pointer ${plugin_dir}/${id}.json not found, nothing to remove"
+    echo "Plugin deregistration ended with rc=0"
+  fi
+
+  # Remove app2app actions from desktop plugin storages
+  # TODO: recognizer deregistration not yet implemented (matches initUtils deregisterApp2App TODO)
+  CONTAINER_INSTANCE_DIR="${ZWED_instanceDir:-${ZWE_zowe_workspaceDirectory}/app-server}"
+  if [ -n "${CONTAINER_INSTANCE_DIR}" ]; then
+    for desktop_plugin in ng2desktop ivydesktop; do
+      actions_file="${CONTAINER_INSTANCE_DIR}/ZLUX/pluginStorage/org.zowe.zlux.${desktop_plugin}/actions/${id}"
+      if [ -f "${actions_file}" ]; then
+        rm "${actions_file}"
+      fi
+    done
+  else
+    echo "Warning: could not determine instance directory, skipping app2app deregistration"
+  fi
+}
+
+
+if [ -n "$ZLUX_CONTAINER_MODE" ]; then
+  uninstallNojs
+else
+  echo "Testing if node exists"
+  type ${NODE_BIN}
+  if [ $? -ne 0 ]; then
+    echo "Error: node not found, cannot deregister plugin"
     echo "Plugin deregistration ended with rc=1"
     exit 1
   fi
+
+  # normal case follows
+  if [ -z "$ZLUX_INSTALL_LOG_DIR" ]; then
+    if [ -d "${ZWE_zowe_logDirectory}" ]; then
+      ZLUX_INSTALL_LOG_DIR="$ZWE_zowe_logDirectory"
+    fi
+  fi
+
+  PLUGIN_LOG_FILE=/dev/null
+  if [ ! -z "$ZLUX_INSTALL_LOG_DIR" ]; then
+    if [ ! -d "$ZLUX_INSTALL_LOG_DIR" ]; then
+      echo "Will make log directory $ZLUX_INSTALL_LOG_DIR"
+      mkdir -p $ZLUX_INSTALL_LOG_DIR
+    fi
+    PLUGIN_NICKNAME=$(basename "$app_input")
+    PLUGIN_TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+    PLUGIN_LOG_FILE="$ZLUX_INSTALL_LOG_DIR/uninstall-app-${PLUGIN_NICKNAME}-${PLUGIN_TIMESTAMP}.log"
+  fi
+
+  echo "Running app-server plugin deregistration. Log=$PLUGIN_LOG_FILE"
+  echo "app_input=${app_input}"
+  echo "plugin_dir=${plugin_dir}"
+  { ${NODE_BIN} ${zlux_path}/zlux-app-server/lib/uninstall-app.js -i "$app_input" -p "$plugin_dir" $@ 2>&1 ; echo "Plugin deregistration ended with rc=$?" ; } | tee -a $PLUGIN_LOG_FILE
 fi
 
-if [ -n "${plugin_dir}" ]; then
-  echo "Deregistering plugin ${app_id} from ${plugin_dir}"
-  if [ ! -d "${plugin_dir}" ]; then
-    echo "Plugins directory does not exist or is not a directory"
-    exit 1
-  fi
-  if [ -e "${plugin_dir}/${app_id}.json" ]; then
-    rm "${plugin_dir}/${app_id}.json"
-  fi
-  result=$?
-  echo "Plugin deregistration ended with rc=$result"
-  exit $result
-else
-  echo "Could not find plugins directory"
-  echo "Plugin deregistration ended with rc=1"
-  exit 1
-fi

--- a/lib/install-app.js
+++ b/lib/install-app.js
@@ -1,0 +1,99 @@
+/*
+ This program and the accompanying materials are
+ made available under the terms of the Eclipse Public License v2.0 which accompanies
+ this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+ SPDX-License-Identifier: EPL-2.0
+
+ Copyright Contributors to the Zowe Project.
+*/
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const initUtils = require('./initUtils');
+
+// --- Argument parsing ---
+// Accepted flags: -i <inputApp>  -p <pluginsDir>  -v
+const args = process.argv.slice(2);
+let inputApp;
+let pluginsDir;
+let verbose = false;
+
+for (let i = 0; i < args.length; i++) {
+  switch (args[i]) {
+    case '-i': inputApp   = args[++i]; break;
+    case '-p': pluginsDir = args[++i]; break;
+    case '-v': verbose    = true;      break;
+    default:
+      console.error(`Unknown argument: ${args[i]}`);
+      console.error('Usage: install-app.js -i <inputApp> -p <pluginsDir> [-v]');
+      process.exit(1);
+  }
+}
+
+if (!inputApp || !pluginsDir) {
+  console.error('Usage: install-app.js -i <inputApp> -p <pluginsDir> [-v]');
+  process.exit(1);
+}
+
+inputApp   = path.resolve(inputApp);
+pluginsDir = path.resolve(pluginsDir);
+
+// --- Resolve instanceDir (required for actions/recognizers) ---
+const instanceDir = process.env.ZWED_instanceDir;
+if (!instanceDir) {
+  console.error('Error: ZWED_instanceDir environment variable is not set. Cannot determine plugin storage location.');
+  process.exit(1);
+}
+
+// --- Resolve runtimeDirectory (optional; used for relative pointer paths) ---
+const runtimeDirectory = process.env.ZWE_zowe_runtimeDirectory || '';
+
+// --- Build storage directory arrays (mirrors initInstance.js lines 63-66) ---
+const desktopPlugins = ['ng2desktop', 'ivydesktop'];
+const recognizersPluginStorages = desktopPlugins.map(
+  plugin => path.join(instanceDir, 'ZLUX', 'pluginStorage', `org.zowe.zlux.${plugin}`, 'recognizers')
+);
+const actionsPluginStorages = desktopPlugins.map(
+  plugin => path.join(instanceDir, 'ZLUX', 'pluginStorage', `org.zowe.zlux.${plugin}`, 'actions')
+);
+
+// Ensure storage directories exist before writing
+recognizersPluginStorages.forEach(d => initUtils.mkdirp(d, initUtils.FOLDER_MODE));
+actionsPluginStorages.forEach(d => initUtils.mkdirp(d, initUtils.FOLDER_MODE));
+
+// --- Read pluginDefinition.json ---
+const pluginDefPath = path.join(inputApp, 'pluginDefinition.json');
+let pluginDefinition;
+try {
+  pluginDefinition = JSON.parse(fs.readFileSync(pluginDefPath, 'utf8'));
+} catch (e) {
+  console.error(`Error: Could not read pluginDefinition.json from ${inputApp}. ${e.message}`);
+  process.exit(1);
+}
+
+if (!pluginDefinition.identifier) {
+  console.error(`Error: pluginDefinition.json in ${inputApp} is missing 'identifier' field.`);
+  process.exit(1);
+}
+
+if (verbose) {
+  console.log(`Registering plugin ${pluginDefinition.identifier} from ${inputApp}`);
+  console.log(`  pluginsDir: ${pluginsDir}`);
+  console.log(`  instanceDir: ${instanceDir}`);
+  console.log(`  runtimeDirectory: ${runtimeDirectory || '(none)'}`);
+}
+
+// --- Register the plugin (pointer JSON + actions + recognizers) ---
+try {
+  initUtils.registerPlugin(inputApp, pluginDefinition, pluginsDir,
+    actionsPluginStorages, recognizersPluginStorages, runtimeDirectory);
+} catch (e) {
+  console.error(`Error: Failed to register plugin ${pluginDefinition.identifier}. ${e.message}`);
+  process.exit(1);
+}
+
+console.log(`Plugin ${pluginDefinition.identifier} registered successfully.`);
+console.log(`Plugin registration ended with rc=0`);

--- a/lib/uninstall-app.js
+++ b/lib/uninstall-app.js
@@ -1,0 +1,93 @@
+/*
+ This program and the accompanying materials are
+ made available under the terms of the Eclipse Public License v2.0 which accompanies
+ this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+ SPDX-License-Identifier: EPL-2.0
+
+ Copyright Contributors to the Zowe Project.
+*/
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const initUtils = require('./initUtils');
+
+// --- Argument parsing ---
+// Accepted flags: -i <appIdOrPath>  -p <pluginsDir>  -v
+const args = process.argv.slice(2);
+let input;
+let pluginsDir;
+let verbose = false;
+
+for (let i = 0; i < args.length; i++) {
+  switch (args[i]) {
+    case '-i': input      = args[++i]; break;
+    case '-p': pluginsDir = args[++i]; break;
+    case '-v': verbose    = true;      break;
+    default:
+      console.error(`Unknown argument: ${args[i]}`);
+      console.error('Usage: uninstall-app.js -i <appIdOrPath> -p <pluginsDir> [-v]');
+      process.exit(1);
+  }
+}
+
+if (!input || !pluginsDir) {
+  console.error('Usage: uninstall-app.js -i <appIdOrPath> -p <pluginsDir> [-v]');
+  process.exit(1);
+}
+
+pluginsDir = path.resolve(pluginsDir);
+
+// --- Resolve app identifier ---
+// If input resolves to a directory, read identifier from pluginDefinition.json.
+// Otherwise treat the string as a bare plugin identifier.
+let appId;
+const resolvedInput = path.resolve(input);
+try {
+  if (fs.statSync(resolvedInput).isDirectory()) {
+    const pluginDef = JSON.parse(
+      fs.readFileSync(path.join(resolvedInput, 'pluginDefinition.json'), 'utf8')
+    );
+    if (!pluginDef.identifier) {
+      console.error(`Error: pluginDefinition.json in ${resolvedInput} is missing 'identifier' field.`);
+      process.exit(1);
+    }
+    appId = pluginDef.identifier;
+  } else {
+    appId = input;
+  }
+} catch (e) {
+  // statSync failed or JSON parse failed — treat input as a bare identifier
+  appId = input;
+}
+
+// --- Resolve instanceDir (required for actions storage) ---
+const instanceDir = process.env.ZWED_instanceDir;
+if (!instanceDir) {
+  console.error('Error: ZWED_instanceDir environment variable is not set. Cannot determine plugin storage location.');
+  process.exit(1);
+}
+
+// --- Build actions storage directory arrays (mirrors initInstance.js lines 63-66) ---
+const desktopPlugins = ['ng2desktop', 'ivydesktop'];
+const actionsPluginStorages = desktopPlugins.map(
+  plugin => path.join(instanceDir, 'ZLUX', 'pluginStorage', `org.zowe.zlux.${plugin}`, 'actions')
+);
+
+if (verbose) {
+  console.log(`Deregistering plugin ${appId}`);
+  console.log(`  pluginsDir: ${pluginsDir}`);
+  console.log(`  instanceDir: ${instanceDir}`);
+}
+
+// --- Remove pointer JSON and actions ---
+// deregisterPlugin removes the pointer JSON; it falls back to deregisterApp2App only
+// when the pointer file is not found. Call deregisterApp2App explicitly afterwards so
+// actions are always cleaned up regardless.
+initUtils.deregisterPlugin({ identifier: appId }, pluginsDir, actionsPluginStorages);
+initUtils.deregisterApp2App(appId, actionsPluginStorages);
+
+console.log(`Plugin ${appId} deregistered successfully.`);
+console.log(`Plugin deregistration ended with rc=0`);


### PR DESCRIPTION
This PR aligns the windows install/uninstall app scripts to mirror the unix ones, and makes improvements to them both:

1) the log files now contain a timestamp and nickname so that they dont overwrite each other on multiple install/uninstall calls
2) app2app assets are handled better. the "nojs" (container) case didn't handle them at all prior. now actions (but not recognizers still) are handled there.
3) refactored zsf install-app.js to be based upon initUtils.js, it had a lot of duplicate logic.
4) moved install-app.js from zsf to this repo, to make that dependency organized.
5) created an uninstall-app.js to make the uninstall scripts clean by relying upon initUtils.js code again.


As a result you should find this PR unifies and simplifies the code around plugin install/uninstall, and improves parity between different environments of windows/zos/linux/containers