### PR TITLE
Set specific versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "zlux-app-server",
       "version": "1.0.0",
       "dependencies": {
-        "yaml": "~2.4.5",
+        "yaml": "2.4.5",
         "zlux-server-framework": "file:../zlux-server-framework"
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"Warning: no test specified\" && exit 0"
   },
   "dependencies": {
-    "yaml": "~2.4.5",
+    "yaml": "2.4.5",
     "zlux-server-framework": "file:../zlux-server-framework"
   }
 }


### PR DESCRIPTION
This PR sets all package.json versions to what was found in package-lock.json to set a baseline for specific versions rather than relying on version ranges.