### PR TITLE
Remove Startup Folders When Plugin Is Removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to the Zlux App Server package will be documented in this fi
 
 ## v3.6.0
 - Enhancement: Plugins can now ship start menu folders by placing a `folders.json` in `config/startMenuFolders/`. On server startup, `initUtils.js` copies this file to the desktop's plugin storage so the desktop can render shipped folder links in the launch menu. `initInstance.js` includes a fallback scan of registered plugin references for dev environments where `ZWE_INSTALLED_COMPONENTS` is not set. Related to desktop shortcuts PR: [zlux-app-manager#695](https://github.com/zowe/zlux-app-manager/pull/695)
-- Bugfix: Start menu folder files were not cleaned up when a plugin was disabled or deregistered, leaving stale entries in the launch menu. `deregisterPlugin` now removes the corresponding `<pluginId>.json` from the start menu folders storage.
 
 ## v3.5.0
 - Enhancement: App-server startup no longer runs certificate validation as that has been migrated to the zwe launcher startup process to work for all components. [(#364)](https://github.com/zowe/zlux-app-server/pull/364)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Zlux App Server package will be documented in this fi
 
 ## v3.6.0
 - Enhancement: Plugins can now ship start menu folders by placing a `folders.json` in `config/startMenuFolders/`. On server startup, `initUtils.js` copies this file to the desktop's plugin storage so the desktop can render shipped folder links in the launch menu. `initInstance.js` includes a fallback scan of registered plugin references for dev environments where `ZWE_INSTALLED_COMPONENTS` is not set. Related to desktop shortcuts PR: [zlux-app-manager#695](https://github.com/zowe/zlux-app-manager/pull/695)
+- Bugfix: Start menu folder files were not cleaned up when a plugin was disabled or deregistered, leaving stale entries in the launch menu. `deregisterPlugin` now removes the corresponding `<pluginId>.json` from the start menu folders storage.
 
 ## v3.5.0
 - Enhancement: App-server startup no longer runs certificate validation as that has been migrated to the zwe launcher startup process to work for all components. [(#364)](https://github.com/zowe/zlux-app-server/pull/364)

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -288,7 +288,7 @@ INSTALLED_COMPONENTS.forEach(function(installedComponent) {
             initUtils.registerPlugin(fullPath, pluginDefinitionJson, config.pluginsDir, actionsPluginStorages, recognizersPluginStorages, RUNTIME_DIRECTORY, startMenuFoldersStorage);
           } else {
             initUtils.printFormattedDebug(`Deregistering plugin ${fullPath}`);
-            initUtils.deregisterPlugin(pluginDefinitionJson, config.pluginsDir, actionsPluginStorages);
+            initUtils.deregisterPlugin(pluginDefinitionJson, config.pluginsDir, actionsPluginStorages, startMenuFoldersStorage);
           }
         } else {
           initUtils.printFormattedError(`Skipping plugin at ${fullPath} due to pluginDefinition missing or invalid`);

--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -123,18 +123,31 @@ function fileExists(file) {
 module.exports.fileExists = fileExists;
 
 
-function deregisterPlugin(pluginDefinition, pluginPointerDirectory, actionsDirectories) {
+function deregisterPlugin(pluginDefinition, pluginPointerDirectory, actionsDirectories, startMenuFoldersLocation) {
   const filePath = `${pluginPointerDirectory}/${pluginDefinition.identifier}.json`;
+  let removed = false;
   if (fileExists(filePath, true)) {
     try {
       fs.unlinkSync(filePath);
+      removed = true;
     } catch (e) {
       printFormattedError(`Could not deregister plugin ${pluginDefinition.identifier}, delete ${filePath} failed, error=${e}`);
     }
-    return true;
   } else {
-    return deregisterApp2App(pluginDefinition.identifier, actionsDirectories);
+    removed = deregisterApp2App(pluginDefinition.identifier, actionsDirectories);
   }
+  if (startMenuFoldersLocation) {
+    const startMenuFile = path.resolve(startMenuFoldersLocation, pluginDefinition.identifier + '.json');
+    if (fileExists(startMenuFile, true)) {
+      try {
+        fs.unlinkSync(startMenuFile);
+        printFormattedDebug(`Removed start menu folders for ${pluginDefinition.identifier}`);
+      } catch (e) {
+        printFormattedError(`Could not remove start menu folders for ${pluginDefinition.identifier}: ${e.message}`);
+      }
+    }
+  }
+  return removed;
 }
 module.exports.deregisterPlugin = deregisterPlugin;
 


### PR DESCRIPTION
## Proposed changes

When a plugin that ships start menu folders (`config/startMenuFolders/folders.json`) is disabled or deregistered, the corresponding `<pluginId>.json` file in the desktop's `ui/startMenu/folders` plugin storage was never cleaned up. This left behind dead files that caused the desktop to render stale/orphaned folder entries in the launch menu.

This PR updates `deregisterPlugin` in initUtils.js to also remove the start menu folders JSON for the plugin being deregistered, and passes the `startMenuFoldersStorage` path from initInstance.js to the deregistration call.

This PR depends upon the following PRs:
- https://github.com/zowe/zlux-app-server/pull/360 (merged -- introduced start menu folder registration)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist
- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Relevant update to CHANGELOG.md

## Testing

1. Register a plugin that ships `config/startMenuFolders/folders.json` (e.g. a test plugin).
2. Run initInstance.js -- verify `<instanceDir>/ZLUX/pluginStorage/org.zowe.zlux.ivydesktop/ui/startMenu/folders/<pluginId>.json` is created.
3. Disable the plugin in the component manifest (`enabled: false`) and re-run initInstance.js.
4. Verify the `<pluginId>.json` file is removed from the start menu folders storage directory.
5. Confirm the desktop launch menu no longer shows the folder entries from the removed plugin.

## Further comments

The `deregisterPlugin` function signature now accepts an optional 4th parameter `startMenuFoldersLocation`. When not provided (backward-compatible), cleanup is skipped. The original early `return true` was refactored to use a `removed` flag so that start menu cleanup always executes regardless of whether the pointer file deletion succeeded.