### PR TITLE
`lib/initInstance.js`: replace `execSync` with `execFileSync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.6.0
-- Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#???)](https://github.com/zowe/zlux-app-server/pull/???)
+- Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#378)](https://github.com/zowe/zlux-app-server/pull/378)
 - Enhancement: Plugins can now ship start menu folders by placing a `folders.json` in `config/startMenuFolders/`. On server startup, `initUtils.js` copies this file to the desktop's plugin storage so the desktop can render shipped folder links in the launch menu. `initInstance.js` includes a fallback scan of registered plugin references for dev environments where `ZWE_INSTALLED_COMPONENTS` is not set. Related to desktop shortcuts PR: [zlux-app-manager#695](https://github.com/zowe/zlux-app-manager/pull/695)
 
 ## v3.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.6.0
+- Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#???)](https://github.com/zowe/zlux-app-server/pull/???)
 - Enhancement: Plugins can now ship start menu folders by placing a `folders.json` in `config/startMenuFolders/`. On server startup, `initUtils.js` copies this file to the desktop's plugin storage so the desktop can render shipped folder links in the launch menu. `initInstance.js` includes a fallback scan of registered plugin references for dev environments where `ZWE_INSTALLED_COMPONENTS` is not set. Related to desktop shortcuts PR: [zlux-app-manager#695](https://github.com/zowe/zlux-app-manager/pull/695)
 
 ## v3.5.0

--- a/lib/initInstance.js
+++ b/lib/initInstance.js
@@ -17,7 +17,7 @@ const yamlConfig = require('../../zlux-server-framework/utils/yamlConfig');
 const initUtils = require('./initUtils');
 //const upgradeInstance = require('./upgradeInstance');
 const os = require('os');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 initUtils.printFormattedDebug(`Started initInstance.js, platform=${os.platform()}`);
 
@@ -157,8 +157,16 @@ if (siteStorage.length == 0 && instanceStorage.length == 0) {
       generateComponentJson()
     });
   } else {
-    execSync("cp -r "+path.join(config.productDir, 'ZLUX', 'pluginStorage')+" "+path.join(config.instanceDir, 'ZLUX'));
-    execSync("chmod -R 770 "+instancePluginStorage);
+    try {
+      execFileSync("cp", ["-r",
+        path.join(config.productDir, 'ZLUX', 'pluginStorage'),
+        path.join(config.instanceDir, 'ZLUX')
+      ]);
+      execFileSync("chmod", ["-R", "770", instancePluginStorage]);
+    } catch (err) {
+      console.warn('ZWED5005W - Warning: error while copying plugin preferences into instance', err);
+      process.exit(1);
+    }
     generateComponentJson()
   }
 }


### PR DESCRIPTION
There is an advantage of `execFileSync` to take care about input to prevent shell injection.

_Note:_ If ok, this needs to be in V2.