### PR TITLE
`configure.sh`: use set & sed & awk to replace variables

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -34,17 +34,26 @@ if [ "$apiml_enabled" = "true" ]; then
   if [ "$ZWE_components_zss_enabled" = "true" ]; then
     if [ "${ZWE_RUN_ON_ZOS}" != "true" ]; then
       zss_def_template="zss.apiml_static_reg.yaml.template"
-      export ZSS_PORT="${ZWE_components_zss_port}"
-  
       if [ -n "${ZWE_STATIC_DEFINITIONS_DIR}" ]; then
         zss_registration_yaml=${ZWE_STATIC_DEFINITIONS_DIR}/zss.apiml_static_reg_yaml_template.${ZWE_CLI_PARAMETER_HA_INSTANCE}.yml
-        zss_def="../${zss_def_template}"
-        zss_parsed_def=$( ( echo "cat <<EOF" ; cat "${zss_def}" ; echo ; echo EOF ) | sh 2>&1)
-        echo "${zss_parsed_def}" > "${zss_registration_yaml}"
-        chmod 770 "${zss_registration_yaml}"
+        awk -v   zah="$(set | sed -n 's/^ZWED_agent_host=//p' | sed 's/^"//;s/"$//')" \
+          -v      zp="$(set | sed -n 's/^ZWE_components_zss_port=//p' | sed 's/^"//;s/"$//')" \
+          -v     zhh="$(set | sed -n 's/^ZWE_haInstance_hostname=//p' | sed 's/^"//;s/"$//')" \
+          -v   zcasp="$(set | sed -n 's/^ZWE_components_app_server_port=//p' | sed 's/^"//;s/"$//')" \ '
+          BEGIN {
+              RESTRICTED_ENV["ZWED_agent_host"] = zah
+              RESTRICTED_ENV["ZSS_PORT"] = zp
+              RESTRICTED_ENV["ZWE_haInstance_hostname"] = zhh
+              RESTRICTED_ENV["ZWE_components_app_server_port"] = zcasp
+          }
+          {
+            for (v in RESTRICTED_ENV) {
+              gsub("\\$[{]" v "[}]", RESTRICTED_ENV[v])
+            }
+            print
+          }' "${zss_def_template}" > "${zss_registration_yaml}"
+        chmod 660 "${zss_registration_yaml}"
       fi
-    
-      unset ZSS_PORT
     fi
   fi
 fi


### PR DESCRIPTION
## Changes

### Replace variables

Why so complicated? I did not find a better way.

#### Pros
We don't care, what's inside the variable, it is treated as text.

#### Cons
* Complicated code, for any change in template, this code must be changed.
* Does not handle shell features like setting default value etc.
* Handles only `${VAR}`

### chmod

Originally there was `chmod 770 "${zss_registration_yaml}"` for a YAML file. Is there a reason to define a YAML file with execute permission?

### Unit test

```shell
#!/bin/sh

ZWED_agent_host='$(ls)'
ZWE_components_zss_port=';cat /etc/passwd;'
ZWE_haInstance_hostname='`exit 1`';
ZWE_components_app_server_port='. ./bad_code.sh'

awk -v   zah="$(set | sed -n 's/^ZWED_agent_host=//p' | sed 's/^"//;s/"$//')" \
    -v    zp="$(set | sed -n 's/^ZWE_components_zss_port=//p' | sed 's/^"//;s/"$//')" \
    -v   zhh="$(set | sed -n 's/^ZWE_haInstance_hostname=//p' | sed 's/^"//;s/"$//')" \
    -v zcasp="$(set | sed -n 's/^ZWE_components_app_server_port=//p' | sed 's/^"//;s/"$//')" \ '
         BEGIN {
            RESTRICTED_ENV["ZWED_agent_host"] = zah
            RESTRICTED_ENV["ZSS_PORT"] = zp
            RESTRICTED_ENV["ZWE_haInstance_hostname"] = zhh
            RESTRICTED_ENV["ZWE_components_app_server_port"] = zcasp
        }
        {
          for (v in RESTRICTED_ENV) {
            gsub("\\$[{]" v "[}]", RESTRICTED_ENV[v])
          }
          print
        }' zss.apiml_static_reg.yaml.template > zss.apiml_static_reg.yaml

cat zss.apiml_static_reg.yaml
```
```
services:
  - serviceId: zss
    title: Zowe System Services (ZSS)
    description: 'Zowe System Services is an HTTPS and Websocket server that makes it easy to have secure, powerful web APIs backed by low-level z/OS constructs. It contains services for essential z/OS abilities such as working with files, datasets, and ESMs, but is also extensible by REST and Websocket "Dataservices" which are optionally present in App Framework "Plugins".'
    catalogUiTileId: zss
    instanceBaseUrls:
      - https://$(ls):;cat /etc/passwd;/
    homePageRelativeUrl:
    routedServices:
      - gatewayUrl: api/v1
        serviceRelativeUrl:
    apiInfo:
      - apiId: zowe.zss
        gatewayUrl: api/v1
        swaggerUrl: https://`exit 1`:. ./bad_code.sh/api-docs/agent
        # documentationUrl: TODO
catalogUiTiles:
  zss:
    title: Zowe System Services (ZSS)
    description:  Zowe System Services is an HTTPS and Websocket server that makes it easy to have secure, powerful web APIs backed by low-level z/OS constructs.
```