### PR TITLE
Validate application ID directory before removal

### DIFF
--- a/bin/uninstall-app.sh
+++ b/bin/uninstall-app.sh
@@ -65,7 +65,7 @@ if [ -n "${plugin_dir}" ]; then
   if [ -e "${plugin_dir}/${app_id}.json" ]; then
     abs_plugin_dir=$(cd "${plugin_dir}" 2>/dev/null && pwd)
     abs_base_dir=$(cd "$(dirname "${plugin_dir}/${app_id}.json")" 2>/dev/null && pwd)
-    if [ "${abs_base_dir}" = "${abs_plugin_dir}" ]; then
+    if [[ "${abs_base_dir}" == "${abs_plugin_dir}"* ]]; then
         rm "${plugin_dir}/${app_id}.json"
     else
       echo "Application ID not in the plugin directory: ${plugin_dir}/${app_id}.json"

--- a/bin/uninstall-app.sh
+++ b/bin/uninstall-app.sh
@@ -63,7 +63,15 @@ if [ -n "${plugin_dir}" ]; then
     exit 1
   fi
   if [ -e "${plugin_dir}/${app_id}.json" ]; then
-    rm "${plugin_dir}/${app_id}.json"
+    abs_plugin_dir=$(cd "${plugin_dir}" 2>/dev/null && pwd)
+    abs_base_dir=$(cd "$(dirname "${plugin_dir}/${app_id}.json")" 2>/dev/null && pwd)
+    if [ "${abs_base_dir}" = "${abs_plugin_dir}" ]; then
+        rm "${plugin_dir}/${app_id}.json"
+    else
+      echo "Application ID not in the plugin directory: ${plugin_dir}/${app_id}.json"
+      echo "Plugin deregistration ended with rc=1"
+      exit 1      
+    fi
   fi
   result=$?
   echo "Plugin deregistration ended with rc=$result"


### PR DESCRIPTION
Before the `plugin.json` is deleted, we'll check if the plugin is really inside the plugin directory to avoid accidental deletion of the plugin outside the plugin directory.


```shell
#!/bin/sh

# Expected directory structure
# /zowe/pokus.json
# /zowe/plugins/pokus.json <- we can delete only this one

plugin_dir="/zowe/plugins"
# Points one level up
app_id="../pokus"
# app_id="asdf/pokus" <- we can delete, as it stays in /zowe/plugins

if [ -e "${plugin_dir}/${app_id}.json" ]; then
    abs_plugin_dir=$(cd "${plugin_dir}" 2>/dev/null && pwd)
    abs_base_dir=$(cd "$(dirname "${plugin_dir}/${app_id}.json")" 2>/dev/null && pwd)
    if [[ "${abs_base_dir}" == "${abs_plugin_dir}"* ]]; then
        echo "TEST ONLY: rm ${plugin_dir}/${app_id}.json"
    else
        echo "Application ID outside the plugin directory: ${plugin_dir}/${app_id}.json"
        echo "Plugin deregistration ended with rc=1"
        exit 1      
    fi
fi
```

```
Application ID outside the plugin directory: zowe/plugins/../pokus.json
Plugin deregistration ended with rc=1
```