### PR TITLE
Remove auth trivial plugin

### DIFF
--- a/defaults/plugins/org.zowe.zlux.auth.trivial.json
+++ b/defaults/plugins/org.zowe.zlux.auth.trivial.json
@@ -1,4 +1,0 @@
-{
-  "identifier": "org.zowe.zlux.auth.trivial",
-  "pluginLocation": "../../zlux-server-framework/plugins/trivial-auth"
-}


### PR DESCRIPTION
This pr removes the auth trivial plugin from the defaults folder. 