### PR TITLE
Redact passwords and secrets from startup environment dump

### DIFF
--- a/.github/workflows/build-core.yml
+++ b/.github/workflows/build-core.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - v3.x/staging
 
+permissions:
+  contents: write
+
 jobs:
   build-core:
     uses: zowe/zlux-build/.github/workflows/build-core.yml@v3.x/staging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.6.0
-- Bugfix: App-server startup no longer dumps environment variables containing "password" or "secret" to the startup log.
+- Bugfix: env var logging at startup now omits sensitive variable names. [(#390)](https://github.com/zowe/zlux-app-server/pull/390)
 - Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#378)](https://github.com/zowe/zlux-app-server/pull/378)
 - Enhancement: Plugins can now ship start menu folders by placing a `folders.json` in `config/startMenuFolders/`. On server startup, `initUtils.js` copies this file to the desktop's plugin storage so the desktop can render shipped folder links in the launch menu. `initInstance.js` includes a fallback scan of registered plugin references for dev environments where `ZWE_INSTALLED_COMPONENTS` is not set. Related to desktop shortcuts PR: [zlux-app-manager#695](https://github.com/zowe/zlux-app-manager/pull/695)
 - Bugfix: Default to port 992, tls for tn3270 terminal ([#387](https://github.com/zowe/zlux-app-server/pull/387))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.6.0
+- Bugfix: App-server startup no longer dumps environment variables containing "password" or "secret" to the startup log.
 - Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#378)](https://github.com/zowe/zlux-app-server/pull/378)
 - Enhancement: Plugins can now ship start menu folders by placing a `folders.json` in `config/startMenuFolders/`. On server startup, `initUtils.js` copies this file to the desktop's plugin storage so the desktop can render shipped folder links in the launch menu. `initInstance.js` includes a fallback scan of registered plugin references for dev environments where `ZWE_INSTALLED_COMPONENTS` is not set. Related to desktop shortcuts PR: [zlux-app-manager#695](https://github.com/zowe/zlux-app-manager/pull/695)
 - Bugfix: Default to port 992, tls for tn3270 terminal ([#387](https://github.com/zowe/zlux-app-server/pull/387))

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -129,7 +129,7 @@ fi
 export NODE_ENV=${NODE_ENV:-production}
 
 echo Show Environment
-env
+env | grep -i -v password | grep -i -v secret
 
 cd ${ZLUX_APP_SERVER_DIR}/lib
 echo Starting node


### PR DESCRIPTION
`bin/start.sh` ran `env` unconditionally, writing keystore/truststore passwords and secrets to the group-readable startup log. The environment dump now filters out any line containing "password" or "secret".