### PR TITLE
Fix world-writable log directory in container configure

### DIFF
--- a/bin/configure-container.sh
+++ b/bin/configure-container.sh
@@ -18,7 +18,7 @@ else
   LOG_DIR="${ZWED_INSTALL_DIR}/logs"
 fi
 mkdir -p ${LOG_DIR}
-chmod 777 ${LOG_DIR}
+chmod 775 ${LOG_DIR}
 export LOG_FILE=${LOG_DIR}/"configure-app-server`date +%Y-%m-%d-%H-%M-%S`.log"
 
 # cd /component/bin


### PR DESCRIPTION
`bin/configure-container.sh` created the log directory with `chmod 777`, making it world-writable so any local user on a shared USS/container filesystem could plant symlinks or tamper with audit logs. This changes it to `775`, removing world-write while keeping owner/group access for the container runtime.