### PR TITLE
Redact sensitive values from startup configuration logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.6.0
-- Security: Startup configuration logging (ZWED5015I, ZWED5016I, ZWED5018I) now recursively redacts sensitive values (keys containing PASSWORD, PASSPHRASE, or SECRET) before printing, preventing credentials such as `zowe.certificate.keystore.password` and `node.https.passphrase` from being written to the app-server log.
+- Security: Startup configuration logging (ZWED5015I, ZWED5016I, ZWED5018I) now recursively redacts sensitive values (keys containing PASSWORD, PASSPHRASE, or SECRET) before printing, preventing credentials such as `zowe.certificate.keystore.password` and `node.https.passphrase` from being written to the app-server log. [(#396)](https://github.com/zowe/zlux-app-server/pull/396)
 - Bugfix: env var logging at startup now omits sensitive variable names. [(#390)](https://github.com/zowe/zlux-app-server/pull/390)
 - Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#378)](https://github.com/zowe/zlux-app-server/pull/378)
 - Enhancement: Plugins can now ship start menu folders by placing a `folders.json` in `config/startMenuFolders/`. On server startup, `initUtils.js` copies this file to the desktop's plugin storage so the desktop can render shipped folder links in the launch menu. `initInstance.js` includes a fallback scan of registered plugin references for dev environments where `ZWE_INSTALLED_COMPONENTS` is not set. Related to desktop shortcuts PR: [zlux-app-manager#695](https://github.com/zowe/zlux-app-manager/pull/695)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.6.0
+- Security: Startup configuration logging (ZWED5015I, ZWED5016I, ZWED5018I) now recursively redacts sensitive values (keys containing PASSWORD, PASSPHRASE, or SECRET) before printing, preventing credentials such as `zowe.certificate.keystore.password` and `node.https.passphrase` from being written to the app-server log.
 - Bugfix: env var logging at startup now omits sensitive variable names. [(#390)](https://github.com/zowe/zlux-app-server/pull/390)
 - Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#378)](https://github.com/zowe/zlux-app-server/pull/378)
 - Enhancement: Plugins can now ship start menu folders by placing a `folders.json` in `config/startMenuFolders/`. On server startup, `initUtils.js` copies this file to the desktop's plugin storage so the desktop can render shipped folder links in the launch menu. `initInstance.js` includes a fallback scan of registered plugin references for dev environments where `ZWE_INSTALLED_COMPONENTS` is not set. Related to desktop shortcuts PR: [zlux-app-manager#695](https://github.com/zowe/zlux-app-manager/pull/695)

--- a/lib/zluxArgs.js
+++ b/lib/zluxArgs.js
@@ -37,35 +37,45 @@ if (!userInput.config) {
 //Hack for enabling debug of this process... we need to read config before config is parsed, using env var here. env var translation misses _ and . and -
 let configJSON = yamlConfig.parseZoweDotYaml(userInput.config, haInstanceId, Number(process.env['ZWE_components_app_server_logLevels_zsf_bootstrap'])>3);
 
-function getSafeToPrintEnvironment(env) {
-  const keys = Object.keys(env).filter(key => {
-    const upperCasedKey = key.toUpperCase();
-    if (upperCasedKey.indexOf('PASSWORD') != -1 || upperCasedKey.indexOf('SECRET') != -1) {
-      return false;
+const REDACTED_VALUE = '(redacted)';
+
+function isSensitiveKey(key) {
+  const upperCasedKey = key.toUpperCase();
+  return upperCasedKey.indexOf('PASSWORD') != -1
+    || upperCasedKey.indexOf('PASSPHRASE') != -1
+    || upperCasedKey.indexOf('SECRET') != -1;
+}
+
+//Returns a deep copy with the values of sensitive keys replaced, so config can be logged without leaking credentials.
+function redactSensitive(value) {
+  if (Array.isArray(value)) {
+    return value.map(redactSensitive);
+  }
+  if (value !== null && typeof value === 'object') {
+    const result = {};
+    for (const key of Object.keys(value)) {
+      result[key] = isSensitiveKey(key) ? REDACTED_VALUE : redactSensitive(value[key]);
     }
-    return true;
-  });
-  const safeEnvironment = {};
-  keys.forEach(key => safeEnvironment[key] = env[key]);
-  return safeEnvironment;
+    return result;
+  }
+  return value;
 }
 
 //Env overrides config JSON, -D args override env
 if(process.env.overrideFileConfig !== "false"){
   if (cluster.isPrimary) {
-    const safeEnvironment = getSafeToPrintEnvironment(process.env);
     console.log('\nZWED5014I - Processing CLI arguments:\n'+commandArgs);
   }
   const envConfig = argParser.environmentVarsToObject("ZWED_");
   if (Object.keys(envConfig).length > 0) {
     if (cluster.isPrimary) {
-      console.log('\nZWED5015I - Processed environment variables:\n'+JSON.stringify(envConfig, null, 2));
+      console.log('\nZWED5015I - Processed environment variables:\n'+JSON.stringify(redactSensitive(envConfig), null, 2));
     }
     configJSON = Object.assign(configJSON, {components: {"app-server": mergeUtils.deepAssign(configJSON.components['app-server'], envConfig) } });
   }
   if (userInput.D) {
     if (cluster.isPrimary) {
-      console.log('\nZWED5016I - Processed -D arguments:\n'+JSON.stringify(userInput.D, null, 2));
+      console.log('\nZWED5016I - Processed -D arguments:\n'+JSON.stringify(redactSensitive(userInput.D), null, 2));
     }
     configJSON = Object.assign(configJSON, {components: {"app-server": mergeUtils.deepAssign(configJSON.components['app-server'], userInput.D) } })
   }
@@ -79,8 +89,8 @@ if(configJSON.components['app-server'].node.noChild === true){
 }
 
 if (cluster.isPrimary) {
-  let configJSONSafeToPrint = Object.assign({}, configJSON);
-  if (configJSONSafeToPrint.zowe.sysMessages) {
+  let configJSONSafeToPrint = redactSensitive(configJSON);
+  if (configJSONSafeToPrint.zowe && configJSONSafeToPrint.zowe.sysMessages) {
     delete configJSONSafeToPrint.zowe.sysMessages;
   }
 


### PR DESCRIPTION
getSafeToPrintEnvironment() computed a redacted environment that was never used (dead store), while ZWED5015I printed all ZWED_* env vars and ZWED5018I printed the merged config with only zowe.sysMessages removed. These logs exposed credentials such as zowe.certificate.keystore.password and node.https.passphrase on every start.

Replace the unused key filter with a recursive redactSensitive() helper (matching PASSWORD, PASSPHRASE, SECRET) and apply it to the ZWED5015I, ZWED5016I, and ZWED5018I log output. Remove the dead store.

## Proposed changes

This PR fixes a credential-exposure issue in `lib/zluxArgs.js` where secrets were written to the app-server log on every startup.

Previously:
- `getSafeToPrintEnvironment()` computed a redacted copy of `process.env`, but the result was assigned to a local variable that was never used (dead store).
- `ZWED5015I` printed all `ZWED_*` environment variables unredacted.
- `ZWED5018I` printed the entire merged `configJSON` after removing only `zowe.sysMessages`, leaving `zowe.certificate.keystore.password`, `node.https.passphrase`, and any plugin-level credentials in plaintext.

Changes:
- Removed the dead store and the unused `getSafeToPrintEnvironment()` key filter (which also missed `PASSPHRASE`).
- Added a recursive `redactSensitive()` helper that deep-copies objects/arrays and replaces the value of any key containing `PASSWORD`, `PASSPHRASE`, or `SECRET` with `(redacted)`.
- Applied `redactSensitive()` to the `ZWED5015I` (env vars), `ZWED5016I` (-D args), and `ZWED5018I` (merged config) log output. `ZWED5018I` now redacts a deep copy, so nested credentials are masked and the `zowe.sysMessages` removal no longer risks mutating the live config.

This PR addresses Issue: https://github.com/zowe/security-reports/issues (Pen Testing finding, zlux-app-server `lib/zluxArgs.js`)

This PR depends upon the following PRs: N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## PR Checklist

- [x] If the changes in this PR are meant for the next release / mainline, this PR targets the "staging" branch.
- [x] My code follows the style guidelines of this project (see: [Contributing guideline](https://github.com/zowe/zlux/blob/master/CONTRIBUTING.md))
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Relevant update to CHANGELOG.md
- [x] My changes generate no new warnings

## Testing

1. Configure a Zowe app-server with credentials present in the merged config (e.g. `zowe.certificate.keystore.password`, `node.https.passphrase`) and/or set `ZWED_*` environment variables containing `PASSWORD`/`PASSPHRASE`/`SECRET`.
2. Start the app-server.
3. Inspect the startup log output for `ZWED5015I`, `ZWED5016I`, and `ZWED5018I`.
4. Confirm all sensitive values appear as `(redacted)` and no plaintext credentials are present.
5. Confirm non-sensitive configuration is still printed normally and the server starts and functions as before (the live `configJSON` is unaffected -- only a redacted deep copy is logged).

## Further comments

Redaction is key-name based (case-insensitive substring match on `PASSWORD`, `PASSPHRASE`, `SECRET`) and recursive so nested and plugin-level secrets are covered. This matches the existing convention already used for env-var name filtering and keeps the config structure visible for troubleshooting while masking only the values.