### PR TITLE
Fix bug introduced in #380

### DIFF
--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -51,7 +51,7 @@ if [ "$apiml_enabled" = "true" ]; then
               gsub("\\$[{]" v "[}]", RESTRICTED_ENV[v])
             }
             print
-          }' "${zss_def_template}" > "${zss_registration_yaml}"
+          }' "../${zss_def_template}" > "${zss_registration_yaml}"
         chmod 660 "${zss_registration_yaml}"
       fi
     fi


### PR DESCRIPTION
```shell
# Enters the bin directory
cd ${COMPONENT_HOME}/share/zlux-app-server/bin

# template referenced in bin directory - wrong
awk '{something}' template > AbsolutePath.yaml

# updated to expected template one level up
awk '{something}' ../template > AbsolutePath .yaml
```

Thanks to @skurnevich to find this!