### PR TITLE
remove telnet port lookup

### DIFF
--- a/lib/initUtils.js
+++ b/lib/initUtils.js
@@ -422,12 +422,6 @@ module.exports.setTerminalDefaults = function(configDestination, instanceItems) 
     }
   }
   if (instanceItems.indexOf('org.zowe.terminal.tn3270.json') != -1) {
-    if (!process.env['ZWED_TN3270_PORT']) {
-      const telnetPort = readPortFromUnixConfig('/etc/services', /^telnet[\s]+[0-9]{1,5}/i);
-      if (telnetPort) {
-        process.env['ZWED_TN3270_PORT'] = telnetPort;
-      }
-    }
     let security = 'tls';
     if (process.env['ZWED_TN3270_SECURITY']) {
       security = process.env['ZWED_TN3270_SECURITY'];


### PR DESCRIPTION
Despite prior setting the tn3270 default to port 992, we had a gap in that were we were looking up the telnet port and then preferring that.
unfortunately, we cannot do the same sort of lookup for tls, its just not as universally present in /etc/services, so we just have to pray that port 992 is good otherwise the users must adjust their config.