### PR TITLE
Evaluate templates in node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.6.0
+- Security: `configure.sh` is using a Node.js script (`lib/generateZssApimlStaticReg.js`) to performs literal `${VAR}` substitution. [(#4??)](https://github.com/zowe/zlux-app-server/pull/4??)
 - Security: Startup configuration logging (ZWED5014I, ZWED5015I, ZWED5016I, ZWED5018I) now recursively redacts sensitive values (keys containing PASSWORD, PASSPHRASE, or SECRET) before printing, preventing credentials such as `zowe.certificate.keystore.password` and `node.https.passphrase` from being written to the app-server log. The raw CLI argument log (ZWED5014I) is also omitted when the arguments contain a sensitive substring (e.g. a `-D` override carrying a password). [(#399)](https://github.com/zowe/zlux-app-server/pull/399)
 - Bugfix: env var logging at startup now omits sensitive variable names. [(#390)](https://github.com/zowe/zlux-app-server/pull/390)
 - Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#378)](https://github.com/zowe/zlux-app-server/pull/378)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.6.0
-- Security: `configure.sh` is using a Node.js script (`lib/generateZssApimlStaticReg.js`) to performs literal `${VAR}` substitution. [(#4??)](https://github.com/zowe/zlux-app-server/pull/4??)
+- Security: `configure.sh` is using a Node.js script (`lib/generateZssApimlStaticReg.js`) to performs literal `${VAR}` substitution. [(#403)](https://github.com/zowe/zlux-app-server/pull/403)
 - Security: Startup configuration logging (ZWED5014I, ZWED5015I, ZWED5016I, ZWED5018I) now recursively redacts sensitive values (keys containing PASSWORD, PASSPHRASE, or SECRET) before printing, preventing credentials such as `zowe.certificate.keystore.password` and `node.https.passphrase` from being written to the app-server log. The raw CLI argument log (ZWED5014I) is also omitted when the arguments contain a sensitive substring (e.g. a `-D` override carrying a password). [(#399)](https://github.com/zowe/zlux-app-server/pull/399)
 - Bugfix: env var logging at startup now omits sensitive variable names. [(#390)](https://github.com/zowe/zlux-app-server/pull/390)
 - Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#378)](https://github.com/zowe/zlux-app-server/pull/378)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Zlux App Server package will be documented in this file.
 
 ## v3.6.0
-- Security: `configure.sh` is using a Node.js script (`lib/generateZssApimlStaticReg.js`) to performs literal `${VAR}` substitution. [(#403)](https://github.com/zowe/zlux-app-server/pull/403)
+- Security: `configure.sh` is using a Node.js script (`lib/generateApimlStaticReg.js`) to perform literal `${VAR}` substitution for both the app-server and ZSS APIML static registration templates. [(#403)](https://github.com/zowe/zlux-app-server/pull/403)
 - Security: Startup configuration logging (ZWED5014I, ZWED5015I, ZWED5016I, ZWED5018I) now recursively redacts sensitive values (keys containing PASSWORD, PASSPHRASE, or SECRET) before printing, preventing credentials such as `zowe.certificate.keystore.password` and `node.https.passphrase` from being written to the app-server log. The raw CLI argument log (ZWED5014I) is also omitted when the arguments contain a sensitive substring (e.g. a `-D` override carrying a password). [(#399)](https://github.com/zowe/zlux-app-server/pull/399)
 - Bugfix: env var logging at startup now omits sensitive variable names. [(#390)](https://github.com/zowe/zlux-app-server/pull/390)
 - Enhancement: `initInstance` is using `execFileSync` function to copy plug-in preferences into instance. [(#378)](https://github.com/zowe/zlux-app-server/pull/378)

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -23,6 +23,8 @@ fi
 
 cd ${COMPONENT_HOME}/share/zlux-app-server/bin
 
+. ./init/node-init.sh
+
 apiml_enabled=false
 if [ "$ZWE_components_gateway_enabled" = "true" ]; then
   apiml_enabled=true
@@ -36,29 +38,11 @@ if [ "$apiml_enabled" = "true" ]; then
       zss_def_template="zss.apiml_static_reg.yaml.template"
       if [ -n "${ZWE_STATIC_DEFINITIONS_DIR}" ]; then
         zss_registration_yaml=${ZWE_STATIC_DEFINITIONS_DIR}/zss.apiml_static_reg_yaml_template.${ZWE_CLI_PARAMETER_HA_INSTANCE}.yml
-        awk -v   zah="$(set | sed -n 's/^ZWED_agent_host=//p' | sed 's/^"//;s/"$//')" \
-          -v      zp="$(set | sed -n 's/^ZWE_components_zss_port=//p' | sed 's/^"//;s/"$//')" \
-          -v     zhh="$(set | sed -n 's/^ZWE_haInstance_hostname=//p' | sed 's/^"//;s/"$//')" \
-          -v   zcasp="$(set | sed -n 's/^ZWE_components_app_server_port=//p' | sed 's/^"//;s/"$//')" \ '
-          BEGIN {
-              RESTRICTED_ENV["ZWED_agent_host"] = zah
-              RESTRICTED_ENV["ZSS_PORT"] = zp
-              RESTRICTED_ENV["ZWE_haInstance_hostname"] = zhh
-              RESTRICTED_ENV["ZWE_components_app_server_port"] = zcasp
-          }
-          {
-            for (v in RESTRICTED_ENV) {
-              gsub("\\$[{]" v "[}]", RESTRICTED_ENV[v])
-            }
-            print
-          }' "../${zss_def_template}" > "${zss_registration_yaml}"
-        chmod 660 "${zss_registration_yaml}"
+        "$NODE_BIN" ../lib/generateZssApimlStaticReg.js "../${zss_def_template}" "${zss_registration_yaml}"
       fi
     fi
   fi
 fi
 
-
-. ./init/node-init.sh
 cd ../lib
 CONFIG_FILE=$ZWE_CLI_PARAMETER_CONFIG $NODE_BIN initInstance.js

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -38,10 +38,13 @@ if [ "$apiml_enabled" = "true" ]; then
   if [ "$app_server_static" = "true" ] && [ -n "${ZWE_STATIC_DEFINITIONS_DIR}" ]; then
     app_server_def_template="app-server.apiml_static_reg.yaml.template"
     app_server_def="../${app_server_def_template}"
-    export APP_SERVER_VERSION=$(grep '^version:' "${COMPONENT_HOME}/manifest.yaml" | head -1 | sed 's/^version: *//; s/"//g')
-    "$NODE_BIN" ../lib/generateApimlStaticReg.js "${app_server_def}" "${app_server_registration_yaml}.1047"
-    (umask 007 && iconv -f 1047 -t 819 "${app_server_registration_yaml}.1047" > "${app_server_registration_yaml}")
-    rm "${app_server_registration_yaml}.1047"
+    app_server_version_line=$(grep '^version:' "${COMPONENT_HOME}/manifest.yaml" | head -1)
+    APP_SERVER_VERSION=$(printf '%s' "${app_server_version_line}" | sed -n 's/^version:[[:space:]]*"\([^"]*\)".*/\1/p')
+    if [ -z "${APP_SERVER_VERSION}" ]; then
+      APP_SERVER_VERSION=$(printf '%s' "${app_server_version_line}" | sed 's/^version:[[:space:]]*//; s/#.*//; s/[[:space:]]*$//')
+    fi
+    export APP_SERVER_VERSION
+    "$NODE_BIN" ../lib/generateApimlStaticReg.js "${app_server_def}" "${app_server_registration_yaml}"
     chtag -r "${app_server_registration_yaml}"
     unset APP_SERVER_VERSION
   elif [ -n "${ZWE_STATIC_DEFINITIONS_DIR}" ] && [ -f "${app_server_registration_yaml}" ]; then

--- a/bin/configure.sh
+++ b/bin/configure.sh
@@ -39,12 +39,10 @@ if [ "$apiml_enabled" = "true" ]; then
     app_server_def_template="app-server.apiml_static_reg.yaml.template"
     app_server_def="../${app_server_def_template}"
     export APP_SERVER_VERSION=$(grep '^version:' "${COMPONENT_HOME}/manifest.yaml" | head -1 | sed 's/^version: *//; s/"//g')
-    app_server_parsed_def=$( ( echo "cat <<EOF" ; cat "${app_server_def}" ; echo ; echo EOF ) | sh 2>&1)
-    echo "${app_server_parsed_def}" > "${app_server_registration_yaml}.1047"
-    iconv -f 1047 -t 819 "${app_server_registration_yaml}.1047" > "${app_server_registration_yaml}"
+    "$NODE_BIN" ../lib/generateApimlStaticReg.js "${app_server_def}" "${app_server_registration_yaml}.1047"
+    (umask 007 && iconv -f 1047 -t 819 "${app_server_registration_yaml}.1047" > "${app_server_registration_yaml}")
     rm "${app_server_registration_yaml}.1047"
     chtag -r "${app_server_registration_yaml}"
-    chmod 770 "${app_server_registration_yaml}"
     unset APP_SERVER_VERSION
   elif [ -n "${ZWE_STATIC_DEFINITIONS_DIR}" ] && [ -f "${app_server_registration_yaml}" ]; then
     rm -f "${app_server_registration_yaml}"
@@ -55,7 +53,9 @@ if [ "$apiml_enabled" = "true" ]; then
       zss_def_template="zss.apiml_static_reg.yaml.template"
       if [ -n "${ZWE_STATIC_DEFINITIONS_DIR}" ]; then
         zss_registration_yaml=${ZWE_STATIC_DEFINITIONS_DIR}/zss.apiml_static_reg_yaml_template.${ZWE_CLI_PARAMETER_HA_INSTANCE}.yml
-        "$NODE_BIN" ../lib/generateZssApimlStaticReg.js "../${zss_def_template}" "${zss_registration_yaml}"
+        export ZSS_PORT="${ZWE_components_zss_port}"
+        "$NODE_BIN" ../lib/generateApimlStaticReg.js "../${zss_def_template}" "${zss_registration_yaml}"
+        unset ZSS_PORT
       fi
     fi
   fi

--- a/lib/generateApimlStaticReg.js
+++ b/lib/generateApimlStaticReg.js
@@ -13,13 +13,9 @@ const fs = require('fs');
 const [, , templatePath, outputPath] = process.argv;
 
 if (!templatePath || !outputPath) {
-  console.error('generateZssApimlStaticReg - usage: node generateZssApimlStaticReg.js <templatePath> <outputPath>');
+  console.error('generateApimlStaticReg - usage: node generateApimlStaticReg.js <templatePath> <outputPath>');
   process.exit(1);
 }
-
-const ENV_ALIASES = {
-  ZSS_PORT: 'ZWE_components_zss_port'
-};
 
 let template;
 try {
@@ -30,8 +26,7 @@ try {
 }
 
 const rendered = template.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, name) => {
-  const envName = ENV_ALIASES[name] || name;
-  const value = process.env[envName];
+  const value = process.env[name];
   return value === undefined ? '' : value;
 });
 
@@ -39,6 +34,6 @@ try {
   fs.writeFileSync(outputPath, rendered);
   fs.chmodSync(outputPath, 0o660);
 } catch (e) {
-  console.error(`generateZssApimlStaticReg - could not write ${outputPath}: ${e.message}`);
+  console.error(`generateApimlStaticReg - could not write ${outputPath}: ${e.message}`);
   process.exit(1);
 }

--- a/lib/generateZssApimlStaticReg.js
+++ b/lib/generateZssApimlStaticReg.js
@@ -1,0 +1,44 @@
+/*
+ This program and the accompanying materials are
+ made available under the terms of the Eclipse Public License v2.0 which accompanies
+ this distribution, and is available at https://www.eclipse.org/legal/epl-v20.html
+
+ SPDX-License-Identifier: EPL-2.0
+
+ Copyright Contributors to the Zowe Project.
+*/
+
+const fs = require('fs');
+
+const [, , templatePath, outputPath] = process.argv;
+
+if (!templatePath || !outputPath) {
+  console.error('generateZssApimlStaticReg - usage: node generateZssApimlStaticReg.js <templatePath> <outputPath>');
+  process.exit(1);
+}
+
+const ENV_ALIASES = {
+  ZSS_PORT: 'ZWE_components_zss_port'
+};
+
+let template;
+try {
+  template = fs.readFileSync(templatePath, 'utf8');
+} catch (e) {
+  console.error(`ZWED0158E - Could not read template ${templatePath}: ${e.message}`);
+  process.exit(1);
+}
+
+const rendered = template.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (match, name) => {
+  const envName = ENV_ALIASES[name] || name;
+  const value = process.env[envName];
+  return value === undefined ? '' : value;
+});
+
+try {
+  fs.writeFileSync(outputPath, rendered);
+  fs.chmodSync(outputPath, 0o660);
+} catch (e) {
+  console.error(`generateZssApimlStaticReg - could not write ${outputPath}: ${e.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Change
* `app-server.apiml_static_reg.yaml.template` and `zss.apiml_static_reg.yaml.template` evaluated via NodeJS script
  * `iconv` removed for `app-server.apiml_static_reg.yaml.template1`
* `chtag -r ` only for z/OS branch
* `APP_SERVER_VERSION` could be with comment
```yaml
# returns 3.6.0
version: "3.6.0" # Comment on the line

# returns #3.7.0
version: "#3.7.0" # New version
```

### Templates tags
```
- untagged    T=off app-server.apiml_static_reg_yaml_template.TEST.yml
t ISO8859-1   T=on  zss.apiml_static_reg_yaml_template.TEST.yml
```

### Version
```yaml
---
name: app-server
id: org.zowe.zlux.app-server
# Without the v
version: "3.6.0" # Version 3.6.0
# Human readable component name
title: Application Server
```

```
cat ./app-server.apiml_static_reg_yaml_template.TEST.yml  | grep version
        version: 3.6.0
```