### PR TITLE
`env` only in debug or trace mode

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -128,8 +128,10 @@ fi
 # set production mode if applicable
 export NODE_ENV=${NODE_ENV:-production}
 
-echo Show Environment
-env | grep -i -v password | grep -i -v secret
+if [ "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "DEBUG" || "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "TRACE" ]; then
+  echo Show Environment
+  env | awk -F= 'BEGIN{IGNORECASE=1} $1 !~ /PASSWORD|PASSPHRASE|SECRET|TOKEN|KEY|CRED/'
+fi
 
 cd ${ZLUX_APP_SERVER_DIR}/lib
 echo Starting node

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -128,7 +128,7 @@ fi
 # set production mode if applicable
 export NODE_ENV=${NODE_ENV:-production}
 
-if [ "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "DEBUG" || "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "TRACE" ]; then
+if [ "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "DEBUG" -o "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "TRACE" ]; then
   echo Show Environment
   env | awk -F= '{ if (toupper($1) !~ /PASSWORD|PASSPHRASE|SECRET|TOKEN|KEY|CRED/) print }'
 fi

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -130,7 +130,7 @@ export NODE_ENV=${NODE_ENV:-production}
 
 if [ "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "DEBUG" || "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "TRACE" ]; then
   echo Show Environment
-  env | awk -F= 'BEGIN{IGNORECASE=1} $1 !~ /PASSWORD|PASSPHRASE|SECRET|TOKEN|KEY|CRED/'
+  env | awk -F= '{ if (toupper($1) !~ /PASSWORD|PASSPHRASE|SECRET|TOKEN|KEY|CRED/) print }'
 fi
 
 cd ${ZLUX_APP_SERVER_DIR}/lib

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -128,10 +128,8 @@ fi
 # set production mode if applicable
 export NODE_ENV=${NODE_ENV:-production}
 
-if [ "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "DEBUG" -o "${ZWE_PRIVATE_LOG_LEVEL_ZWELS}" = "TRACE" ]; then
-  echo Show Environment
-  env | awk -F= '{ if (toupper($1) !~ /PASSWORD|PASSPHRASE|SECRET|TOKEN|KEY|CRED/) print }'
-fi
+echo Show Environment
+env | awk -F= '{ if (toupper($1) !~ /PASSWORD|PASSPHRASE|SECRET|TOKEN|KEY|CRED/) print }'
 
 cd ${ZLUX_APP_SERVER_DIR}/lib
 echo Starting node


### PR DESCRIPTION
* `awk` used to filter names, values are ignored
* more keywords filtered out

```sh
#!/bin/sh

tmpFile="./deleteMe.txt"

echo 'VARIABLE_WITH_NO_SENSITIVE_INFO="I left my keys at home"' > "${tmpFile}"
echo 'PASSWORD="heslo je veslo"' >> "${tmpFile}"
echo 'password="open the door!"' >> "${tmpFile}"
echo 'SECRET=42' >> "${tmpFile}"
echo 'ESM="TOP SECRET"' >> "${tmpFile}"
echo 'TOKEN="1234567890"' >> "${tmpFile}"
echo 'credentials="franta:123456"' >> "${tmpFile}"

# Use cat to simulate env
cat "${tmpFile}" | awk -F= '{ if (toupper($1) !~ /PASSWORD|PASSPHRASE|SECRET|TOKEN|KEY|CRED/) print }'

```

Prints 
```
VARIABLE_WITH_NO_SENSITIVE_INFO="I left my keys at home"
ESM="TOP SECRET"
```
